### PR TITLE
[Live Validator] Do not reject all cache building while one swagger is malicious

### DIFF
--- a/lib/validators/liveValidator.js
+++ b/lib/validators/liveValidator.js
@@ -174,7 +174,8 @@ class LiveValidator {
           return Promise.resolve(self.cache);
         }).catch(function (err) {
           log.debug(`Unable to initialize "${swaggerPath}" file from SpecValidator. Error: ${err}`);
-          return Promise.reject(err);
+          // Do Not reject promise in case, we cannot initialize one of the swagger
+          // return Promise.reject(err);
         });
       }
     });

--- a/lib/validators/liveValidator.js
+++ b/lib/validators/liveValidator.js
@@ -173,9 +173,9 @@ class LiveValidator {
 
           return Promise.resolve(self.cache);
         }).catch(function (err) {
-          log.debug(`Unable to initialize "${swaggerPath}" file from SpecValidator. Error: ${err}`);
           // Do Not reject promise in case, we cannot initialize one of the swagger
-          // return Promise.reject(err);
+          log.debug(`Unable to initialize "${swaggerPath}" file from SpecValidator. Error: ${err}`);
+          log.warn(`Unable to initialize "${swaggerPath}" file from SpecValidator. We are ignoring this swagger file and continuing to build cache for other valid specs.`);
         });
       }
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
Example: https://github.com/Azure/azure-rest-api-specs/pull/1274

```
Building cache from: "/Users/vishrut/repo/monitor/2015-04-01/swagger/tenantActivityLogs_API.json"
error:  SyntaxError: Unexpected token } in JSON at position 2725
    at Object.parse (native)
    at Object.parseContent (/Users/vishrut/git-repos/oav-express/node_modules/oav/lib/util/utils.js:95:19)
    at Object.parseJson (/Users/vishrut/git-repos/oav-express/node_modules/oav/lib/util/utils.js:73:28)
    at SpecValidator.initialize (/Users/vishrut/git-repos/oav-express/node_modules/oav/lib/validators/specValidator.js:90:18)
    at /Users/vishrut/git-repos/oav-express/node_modules/oav/lib/validators/liveValidator.js:135:26
    at process._tickCallback (internal/process/next_tick.js:103:7)
    at Module.runMain (module.js:606:11)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
error: RESOLVE_SPEC_ERROR: Unexpected token } in JSON at position 2725.
error: SyntaxError: Unexpected token } in JSON at position 2725
    at Object.parse (native)
    at Object.parseContent (/Users/vishrut/git-repos/oav-express/node_modules/oav/lib/util/utils.js:95:19)
    at Object.parseJson (/Users/vishrut/git-repos/oav-express/node_modules/oav/lib/util/utils.js:73:28)
    at SpecValidator.initialize (/Users/vishrut/git-repos/oav-express/node_modules/oav/lib/validators/specValidator.js:90:18)
    at /Users/vishrut/git-repos/oav-express/node_modules/oav/lib/validators/liveValidator.js:135:26
    at process._tickCallback (internal/process/next_tick.js:103:7)
    at Module.runMain (module.js:606:11)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
Unable to initialize "/Users/vishrut/repo/monitor/2015-04-01/swagger/tenantActivityLogs_API.json" file from SpecValidator. Error: [object Object]

```