### PR TITLE
less verbose messages and no newline in the end

### DIFF
--- a/lib/autorestPlugin/pluginHost.js
+++ b/lib/autorestPlugin/pluginHost.js
@@ -72,7 +72,9 @@ exports.openApiValidationExample = function openApiValidationExample(swagger, sw
               throw new Error("Model Validator: Path to x-ms-examples not found.");
             }
             //console.error(JSON.stringify(scenarioItem, null, 2));
-            var result = new FormattedOutput("verbose", scenarioItem, scenario, [modelValidationCategory], "Model validator found issue (see details).", [{ document: swaggerFileName, Position: { path: xmsexPath } }])
+            var result = new FormattedOutput("verbose", scenarioItem, scenario, [modelValidationCategory],
+              "Model validator found issue (see details).",
+              [{ document: swaggerFileName, Position: { path: xmsexPath } }])
             formattedResult.push(result);
 
             // request
@@ -88,7 +90,7 @@ exports.openApiValidationExample = function openApiValidationExample(swagger, sw
                 //console.error(JSON.stringify(error, null, 2));
                 resultDetails = { type: "Error", code: error.code, message: error.message, id: error.id, validationCategory: modelValidationCategory, innerErrors: innerError };
                 result = new FormattedOutput("error", resultDetails, [error.code, error.id, modelValidationCategory],
-                  innerError.message + ". \nScenario: " + scenario + ". \nDetails: " + JSON.stringify(innerError.errors, null, 2) + "\nMore info: " + openAPIDocUrl + "#" + error.id.toLowerCase() + "-" + error.code.toLowerCase() + "\n",
+                  innerError.message + ". \nScenario: " + scenario + "\nMore info: " + openAPIDocUrl + "#" + error.id.toLowerCase() + "-" + error.code.toLowerCase(),
                   [{ document: swaggerFileName, Position: { path: path } }]);
                 formattedResult.push(result);
               }
@@ -107,9 +109,8 @@ exports.openApiValidationExample = function openApiValidationExample(swagger, sw
                   //console.error(JSON.stringify(error, null, 2));
                   resultDetails = { type: "Error", code: error.code, message: error.message, id: error.id, validationCategory: modelValidationCategory, innerErrors: innerError };
                   result = new FormattedOutput("error", resultDetails, [error.code, error.id, modelValidationCategory],
-                    innerError.message + ". \nScenario: " + scenario + ". \nDetails: " + JSON.stringify(innerError.errors, null, 2) + "\nMore info: " + openAPIDocUrl + "#" + error.id.toLowerCase() + "-" + error.code.toLowerCase() + "\n",
-                    [{ document: swaggerFileName, Position: { path: xmsexPath.slice(0, xmsexPath.length - 1).concat(["responses", responseCode]) } }
-                    ])
+                    innerError.message + ". \nScenario: " + scenario + "\nMore info: " + openAPIDocUrl + "#" + error.id.toLowerCase() + "-" + error.code.toLowerCase(),
+                    [{ document: swaggerFileName, Position: { path: xmsexPath.slice(0, xmsexPath.length - 1).concat(["responses", responseCode]) } }]);
                   formattedResult.push(result);
                 }
               }


### PR DESCRIPTION
Messages are too verbose (contain JSON blobs) for regular runs and only provide information that is also in the `details` field (where it belongs :wink: ).

Now:
```
ERROR (RESPONSE_VALIDATION_ERROR/OAV108/ExampleModelViolation): Invalid body: Value failed JSON Schema validation.
Scenario: Create/Update data masking rule for default min
More info: https://github.com/Azure/oav#oav108-response_validation_error
  - file:///c:/work/azure-rest-api-specs/specification/sql/resource-manager/Microsoft.Sql/2014-04-01/dataMasking.json:157:20 ($.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/dataMaskingPolicies/{dataMaskingPolicyName}/rules/{dataMaskingRuleName}"].put.responses["200"])
```

Before:
```
ERROR (RESPONSE_VALIDATION_ERROR/OAV108/ExampleModelViolation): Invalid body: Value failed JSON Schema validation.
Scenario: Create/Update data masking rule for default min
Details: [                                                                             
  {                                                                                    
    "code": "OBJECT_ADDITIONAL_PROPERTIES",                                            
    "params": [                                                                        
      [                                                                                
        "location"                                                                     
      ]                                                                                
    ],                                                                                 
    "message": "Additional properties not allowed: location",                          
    "path": [],                                                                        
    "description": "An update request for an Azure SQL Database server."               
  }                                                                                    
]                                                                                      
More info: https://github.com/Azure/oav#oav108-response_validation_error
  - file:///c:/work/azure-rest-api-specs/specification/sql/resource-manager/Microsoft.Sql/2014-04-01/dataMasking.json:157:20 ($.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/dataMaskingPolicies/{dataMaskingPolicyName}/rules/{dataMaskingRuleName}"].put.responses["200"])
```