### PR TITLE
Support status code string for Live Validator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+### 02/05/2018 0.4.29
+- Add support for live validation to support status code string along the status code number.
+- Update to use package autorest-extension-base from npm.
+
 ### 02/01/2018 0.4.28
 - Fix undefined headers issue when the spec does not define consumes values.
 

--- a/lib/autorestPlugin/pluginHost.js
+++ b/lib/autorestPlugin/pluginHost.js
@@ -10,8 +10,7 @@ const yaml = require("js-yaml");
 const utils = require("../util/utils");
 const log = require('../util/logging');
 const SpecValidator = require('../validators/specValidator');
-const extensionBase = require('autorest-extension-base');
-
+const extensionBase = require('@microsoft.azure/autorest-extension-base');
 const openAPIDocUrl = "https://github.com/Azure/oav";
 
 exports = module.exports;

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -10,7 +10,8 @@ var fs = require('fs'),
   YAML = require('js-yaml'),
   log = require('./logging'),
   request = require('request'),
-  lodash = require('lodash');
+  lodash = require('lodash'),
+  http = require('http');
 
 exports = module.exports;
 
@@ -20,7 +21,6 @@ exports = module.exports;
  * value: parsed doc in JSON format
  */
 exports.docCache = {};
-
 
 exports.clearCache = function clearCache() {
   exports.docCache = {};
@@ -759,3 +759,8 @@ exports.getKeys = function getKeys(obj) {
 function isPropertyRequired(propName, model) {
   return model.required ? model.required.some((p) => { return p == propName; }) : false;
 }
+
+/**
+ * Contains the reverse mapping of http.STATUS_CODES
+ */
+exports.statusCodeStringToStatusCode = lodash.invert(http.STATUS_CODES);

--- a/lib/validators/liveValidator.js
+++ b/lib/validators/liveValidator.js
@@ -14,7 +14,8 @@ const util = require('util'),
   Constants = require('../util/constants'),
   log = require('../util/logging'),
   utils = require('../util/utils'),
-  models = require('../models');
+  models = require('../models'),
+  http = require('http');
 
 /**
  * @class
@@ -391,6 +392,11 @@ class LiveValidator {
     }
     let request = requestResponseObj.liveRequest;
     let response = requestResponseObj.liveResponse;
+
+    if (http.STATUS_CODES[response.statusCode] === undefined && utils.statusCodeStringToStatusCode[response.statusCode] !== undefined) {
+      response.statusCode = utils.statusCodeStringToStatusCode[response.statusCode];
+    }
+
     if (!request.query) {
       request.query = url.parse(request.url, true).query;
     }

--- a/lib/validators/liveValidator.js
+++ b/lib/validators/liveValidator.js
@@ -393,7 +393,8 @@ class LiveValidator {
     let request = requestResponseObj.liveRequest;
     let response = requestResponseObj.liveResponse;
 
-    if (http.STATUS_CODES[response.statusCode] === undefined && utils.statusCodeStringToStatusCode[response.statusCode] !== undefined) {
+    // If status code is passed as a status code string (e.g. "OK") tranform it to the status code number (e.g. '200').
+    if (response && !http.STATUS_CODES[response.statusCode] && utils.statusCodeStringToStatusCode[response.statusCode]) {
       response.statusCode = utils.statusCodeStringToStatusCode[response.statusCode];
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@microsoft.azure/autorest-extension-base": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest-extension-base/-/autorest-extension-base-1.0.13.tgz",
+      "integrity": "sha1-/VobUj8CzK3525vK8Jez/5mSgeY=",
+      "requires": {
+        "vscode-jsonrpc": "3.5.0"
+      },
+      "dependencies": {
+        "vscode-jsonrpc": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-3.5.0.tgz",
+          "integrity": "sha1-hyOdnhZrLXNSJFuKgTWXgEwdY6o="
+        }
+      }
+    },
     "@types/form-data": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
@@ -131,12 +146,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "autorest-extension-base": {
-      "version": "github:olydis/autorest-extension-base#61b4aed61232f758c99cad889e16d6bd6c224668",
-      "requires": {
-        "vscode-jsonrpc": "3.4.1"
-      }
     },
     "aws-sign2": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "linq": "^3.0.8",
     "jsonpath": "^0.2.11",
     "vscode-jsonrpc": "^3.2.0",
-    "autorest-extension-base": "olydis/autorest-extension-base",
+    "@microsoft.azure/autorest-extension-base": "^1.0.13",
     "lodash": "^4.17.4",
     "yuml2svg": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
Fixes #209 
Fixes #208 
 - Add support for status code string for Live Validator
 - Update to use autorest-extension-base from official npm package