### PR TITLE
Be more lenient in matching status code string.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+### 02/05/2018 0.4.30
+- Improve matching for status code string for live validation.
+
 ### 02/05/2018 0.4.29
 - Add support for live validation to support status code string along the status code number.
 - Update to use package autorest-extension-base from npm.

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -763,4 +763,4 @@ function isPropertyRequired(propName, model) {
 /**
  * Contains the reverse mapping of http.STATUS_CODES
  */
-exports.statusCodeStringToStatusCode = lodash.invert(http.STATUS_CODES);
+exports.statusCodeStringToStatusCode = lodash.invert(lodash.mapValues(http.STATUS_CODES, value => { return value.replace(/ |-/g, "").toLowerCase(); }));

--- a/lib/validators/liveValidator.js
+++ b/lib/validators/liveValidator.js
@@ -394,8 +394,8 @@ class LiveValidator {
     let response = requestResponseObj.liveResponse;
 
     // If status code is passed as a status code string (e.g. "OK") tranform it to the status code number (e.g. '200').
-    if (response && !http.STATUS_CODES[response.statusCode] && utils.statusCodeStringToStatusCode[response.statusCode]) {
-      response.statusCode = utils.statusCodeStringToStatusCode[response.statusCode];
+    if (response && !http.STATUS_CODES[response.statusCode] && utils.statusCodeStringToStatusCode[response.statusCode.toLowerCase()]) {
+      response.statusCode = utils.statusCodeStringToStatusCode[response.statusCode.toLowerCase()];
     }
 
     if (!request.query) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.4.29",
+  "version": "0.4.30",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
 - we might traffic in various formats ( e.g. C# `HttpStatusCode` enum has the status code without spaces for obvious reasons s) so trying to be more lenient on matching the string.