### PR TITLE
Respect desired logLevel

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -22,7 +22,7 @@ yargs
     alias: 'logLevel',
     describe: 'Set the logging level for console.',
     choices: ['off', 'json', 'error', 'warn', 'info', 'verbose', 'debug', 'silly'],
-    default: 'warn'
+    default: 'info'
   })
   .option('f', {
     alias: 'logFilepath',

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -246,7 +246,9 @@ exports.generateUml = function generateUml(specPath, outputDir, options) {
 };
 
 exports.updateEndResultOfSingleValidation = function updateEndResultOfSingleValidation(validator) {
-  log.info('No Errors were found.');
+  if (validator.specValidationResult.validityStatus) {
+    log.info('No Errors were found.');
+  }
   if (!validator.specValidationResult.validityStatus) {
     process.exitCode = 1;
     exports.finalValidationResult.validityStatus = validator.specValidationResult.validityStatus;

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -247,7 +247,9 @@ exports.generateUml = function generateUml(specPath, outputDir, options) {
 
 exports.updateEndResultOfSingleValidation = function updateEndResultOfSingleValidation(validator) {
   if (validator.specValidationResult.validityStatus) {
-    log.info('No Errors were found.');
+    if (!(log.consoleLogLevel === 'json' || log.consoleLogLevel === 'off')) {
+      log.info('No Errors were found.');
+    }
   }
   if (!validator.specValidationResult.validityStatus) {
     process.exitCode = 1;

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -246,14 +246,7 @@ exports.generateUml = function generateUml(specPath, outputDir, options) {
 };
 
 exports.updateEndResultOfSingleValidation = function updateEndResultOfSingleValidation(validator) {
-  if (validator.specValidationResult.validityStatus) {
-    if (!(log.consoleLogLevel === 'json' || log.consoleLogLevel === 'off')) {
-      let consoleLevel = log.consoleLogLevel;
-      log.consoleLogLevel = 'info';
-      log.info('No Errors were found.');
-      log.consoleLogLevel = consoleLevel;
-    }
-  }
+  log.info('No Errors were found.');
   if (!validator.specValidationResult.validityStatus) {
     process.exitCode = 1;
     exports.finalValidationResult.validityStatus = validator.specValidationResult.validityStatus;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "azure-arm-resource": "^2.0.0-preview",
     "json-pointer": "^0.6.0",
     "js-yaml": "^3.8.2",
-    "moment": "~2.18.1",
+    "moment": "~2.21.0",
     "ms-rest": "^2.3.0",
     "ms-rest-azure": "^2.5.0",
     "request": "^2.83.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "scripts": {
     "jshint": "jshint lib --reporter=jslint",
-    "test": "npm -s run-script jshint && mocha -t 100000",
+    "test": "npm -s run-script jshint && mocha -t 100000 --reporter min",
     "start": "node ./lib/autorestPlugin/pluginHost.js"
   }
 }


### PR DESCRIPTION
Despite setting the consoleLogLevel to 'error' here:
https://github.com/Azure/azure-rest-api-specs/blob/32610853cf560d7454b88ec4ca79a109e8525851/test/semantic.js#L19

A lot of extra lines are being output in CI right now, as seen here:
https://travis-ci.org/Azure/azure-rest-api-specs/jobs/351021743#L694