### PR TITLE
Fix for special symbols inside JSON-Pointer/Reference

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -85,7 +85,7 @@
       "stopOnEntry": false,
       "args": [
         "--no-timeouts",
-        "test/resolveNestedTests.ts",
+        "test/semanticValidatorTests.ts",
         "-r",
         "ts-node/register",
         "--no-timeouts"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 09/10/2018 0.5.8
+
+- Fix JSON-Pointer encoding.
+
 ### 08/28/2018 0.5.7
 
 - Errors have optional `jsonUrl` and `jsonPosition` fields.

--- a/lib/validators/resolveNestedDefinitions.ts
+++ b/lib/validators/resolveNestedDefinitions.ts
@@ -28,6 +28,7 @@ import {
   generatedPrefix,
   getDefaultResponses
 } from './cloudError';
+import { pathToPtr } from 'json-refs';
 
 const skipIfUndefined = <T>(f: (v: T) => T): ((v: T | undefined) => T | undefined) =>
   (v) => v !== undefined ? f(v) : undefined
@@ -64,7 +65,7 @@ export function resolveNestedDefinitions(spec: SwaggerObject, options: Options):
     if (result !== undefined) {
       generatedDefinitions[definitionName] = result
     }
-    return { $ref: `#/definitions/${encodeURIComponent(definitionName)}` }
+    return { $ref: pathToPtr(["definitions", definitionName]) }
   }
 
   // a function to resolve SchemaObject array

--- a/lib/validators/specResolver.ts
+++ b/lib/validators/specResolver.ts
@@ -264,7 +264,7 @@ export class SpecResolver {
    * @return {Promise<void>}
    */
   private async resolveRelativePaths(
-    doc?: unknown,
+    doc?: object,
     docPath?: string,
     filterType?: string
   ): Promise<void> {

--- a/lib/wireFormatGenerator.ts
+++ b/lib/wireFormatGenerator.ts
@@ -192,7 +192,7 @@ export class WireFormatGenerator {
       filter: ["relative", "remote"]
     }
 
-    const allRefsRemoteRelative = JsonRefs.findRefs(this.specInJson, options)
+    const allRefsRemoteRelative = JsonRefs.findRefs(this.specInJson as object, options)
     const e = entries(allRefsRemoteRelative as StringMap<any>)
     const promiseFactories = toArray(map(
       e,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1618,16 +1618,16 @@
       }
     },
     "json-refs": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.6.tgz",
-      "integrity": "sha512-umW/uhtvq2YO+MRtHXUiSIlaoslME3xjnpQJ5rkCQoF5RpDfuBqkbO22W3H4Q16VDOTECKHceqYQzef7sT/Hig==",
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.10.tgz",
+      "integrity": "sha512-hTBuXx9RKpyhNhCEh7AUm0Emngxf9f1caw4BzH9CQSPlTqxSJG/X5W0di8AHSeePu+ZqSYjlXLU6u2+Q/6wFmw==",
       "requires": {
         "commander": "~2.11.0",
         "graphlib": "^2.1.1",
         "js-yaml": "^3.10.0",
         "lodash": "^4.17.4",
         "native-promise-only": "^0.8.1",
-        "path-loader": "^1.0.4",
+        "path-loader": "^1.0.5",
         "slash": "^1.0.0",
         "uri-js": "^3.0.2"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "glob": "^5.0.14",
     "js-yaml": "^3.12.0",
     "json-pointer": "^0.6.0",
-    "json-refs": "3.0.6",
+    "json-refs": "3.0.10",
     "jsonpath": "^1.0.0",
     "linq": "^3.1.0",
     "lodash": "^4.17.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/test/resolveNestedTests.ts
+++ b/test/resolveNestedTests.ts
@@ -11,10 +11,10 @@ const options: sway.Options = {
     definitions: {
       A: {
         properties: {
-          a: {
+          "a": {
             type: "string"
           },
-          b: {
+          "b": {
             properties: {
               c: {
                 type: "string"
@@ -22,6 +22,13 @@ const options: sway.Options = {
             },
             // additionalProperties: false,
             required: ["c"]
+          },
+          "@": {
+            properties: {
+              c: {
+                type: "string"
+              }
+            }
           }
         },
         required: ["a", "b"],
@@ -63,11 +70,14 @@ describe("resolve nested properties", () => {
       url: "example.com",
       method: "x",
       body: {
-        a: "somevalue",
-        b: {
+        "a": "somevalue",
+        "b": {
           c: "somevalue",
           // d: "anothervalue"
         },
+        "@": {
+          c: "somevalue",
+        }
         // d: 54
       }
     }

--- a/test/semanticValidation/specification/parameterizedhost/face.json
+++ b/test/semanticValidation/specification/parameterizedhost/face.json
@@ -1303,6 +1303,13 @@
       "properties": {
         "error": {
           "$ref": "#/definitions/Error"
+        },
+        "@nested": {
+          "properties": {
+            "@a": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/types/json-refs.d.ts
+++ b/types/json-refs.d.ts
@@ -1,6 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License. See License.txt in the project root for license information.
-
-declare module "json-refs" {
-    function findRefs(_0: unknown, _1?: unknown): unknown
-}


### PR DESCRIPTION
https://github.com/Azure/oav/issues/307

BTW,
- [JSON-Schema](https://json-schema.org/understanding-json-schema/structuring.html) is using [JSON Pointer](https://tools.ietf.org/html/rfc6901)
- [OpenAPI](https://swagger.io/docs/specification/using-ref/) is using [JSON Reference](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03)

IMHO `JSON Reference` has a better description of how to decode URI Fragments.