### PR TITLE
OAV shouldn't fail on examples which contain "$schema" properties.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,14 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Validate Network examples",
+      "program": "${workspaceRoot}/dist/scripts/testNetwork.js",
+      "cwd": "${workspaceRoot}",
+      "env": {}
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Extract example",
       "program": "${workspaceRoot}/dist/cli.js",
       "cwd": "${workspaceRoot}",
@@ -109,10 +117,7 @@
       "stopOnEntry": false,
       "args": [
         "--no-timeouts",
-        "test/liveValidatorTests.ts",
-        "-r",
-        "ts-node/register",
-        "--no-timeouts"
+        "dist/test/modelValidatorTests.js"
       ],
       "env": {}
     },

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 01/14/2019 0.11.1
+
+- Replace an example object with a function to avoid reference resolutions in examples.
+
 ### 01/08/2019 0.11.0
 
 - Remove JS symbols from errors to avoid logging failure.

--- a/lib/validators/modelValidator.ts
+++ b/lib/validators/modelValidator.ts
@@ -380,7 +380,8 @@ export class ModelValidator extends SpecValidator<SpecValidationResult> {
       scenarios: resultScenarios
     }
     if (xmsExamples) {
-      for (const [scenario, xmsExample] of entries<any>(xmsExamples)) {
+      for (const [scenario, xmsExampleFunc] of entries<any>(xmsExamples)) {
+        const xmsExample = xmsExampleFunc()
         resultScenarios[scenario] = {
           requestValidation: this.validateRequest(
             operation,
@@ -466,7 +467,7 @@ export class ModelValidator extends SpecValidator<SpecValidationResult> {
 
     let result: RequestValidation = {}
     if (bodyParam && bodyParam.schema && bodyParam.schema.example) {
-      const exampleParameterValues: MutableStringMap<object> = {}
+      const exampleParameterValues: MutableStringMap<(() => {}) | object> = {}
       for (const parameter of parameters) {
         log.debug(
           `Getting sample value for parameter "${

--- a/lib/validators/modelValidator.ts
+++ b/lib/validators/modelValidator.ts
@@ -467,7 +467,7 @@ export class ModelValidator extends SpecValidator<SpecValidationResult> {
 
     let result: RequestValidation = {}
     if (bodyParam && bodyParam.schema && bodyParam.schema.example) {
-      const exampleParameterValues: MutableStringMap<(() => {}) | object> = {}
+      const exampleParameterValues: MutableStringMap<object> = {}
       for (const parameter of parameters) {
         log.debug(
           `Getting sample value for parameter "${

--- a/lib/validators/specResolver.ts
+++ b/lib/validators/specResolver.ts
@@ -388,6 +388,8 @@ export class SpecResolver {
           slicedRefName.match(regex) === null)
       ) {
         // TODO: doc should have a type
+        // We set a function `() => result` instead of an object `result` to avoid
+        // reference resolution in the examples.
         utils.setObject(doc as {}, slicedRefName, () => result)
       }
     } else {

--- a/lib/validators/specResolver.ts
+++ b/lib/validators/specResolver.ts
@@ -106,8 +106,6 @@ export class SpecResolver {
    *
    * @param {object} [options.shouldResolveNullableTypes] Should we allow null values to match any
    *    type? Default: true
-   *
-   * @return {object} An instance of the SpecResolver class.
    */
   public constructor(
     specPath: string,
@@ -390,7 +388,7 @@ export class SpecResolver {
           slicedRefName.match(regex) === null)
       ) {
         // TODO: doc should have a type
-        utils.setObject(doc as {}, slicedRefName, result)
+        utils.setObject(doc as {}, slicedRefName, () => result)
       }
     } else {
       // resolve the local reference.

--- a/lib/xMsExampleExtractor.ts
+++ b/lib/xMsExampleExtractor.ts
@@ -138,7 +138,7 @@ export class XMsExampleExtractor {
 
         const headerParams = recordingEntry.RequestHeaders
 
-        // if commandline included check for API version, validate api-version from URI in
+        // if command-line included check for API version, validate api-version from URI in
         // recordings matches the api-version of the spec
         if (!this.options.matchApiVersion
           || (("api-version" in queryParams)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",
@@ -53,7 +53,7 @@
     "@types/json-pointer": "^1.0.30",
     "@types/jsonpath": "^0.2.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^8.10.34",
+    "@types/node": "^10.12.18",
     "@types/recursive-readdir": "^2.2.0",
     "@types/should": "^8.1.30",
     "@types/swagger-parser": "^4.0.2",

--- a/scripts/testNetwork.ts
+++ b/scripts/testNetwork.ts
@@ -1,0 +1,66 @@
+import * as oav from "../index"
+//import * as fs from "fs"
+//import * as it from "@ts-common/iterator"
+//import * as path from "path"
+
+const f = async () => {
+  /*
+  const p = [
+    "2015-06-15",
+    "2016-03-30",
+    "2016-06-01",
+    "2016-09-01",
+    "2016-12-01",
+    "2017-03-01",
+    "2017-06-01",
+    "2017-08-01",
+    "2017-09-01",
+    "2017-10-01",
+    "2017-11-01",
+
+    "2018-01-01",
+    "2018-02-01",
+    "2018-04-01",
+    "2018-06-01",
+    "2018-07-01",
+    "2018-08-01",
+    "2018-10-01",
+    "2018-11-01",
+  ]
+
+  const getFiles = (aa: ReadonlyArray<string>) => it.flatMap(
+    aa,
+    dn => {
+      const i = path.join(
+        // tslint:disable-next-line:max-line-length
+        "C:/github.com/Azure/azure-rest-api-specs/specification/network/resource-manager/Microsoft.Network/stable/",
+        dn
+      )
+      return it.flatMap(
+        fs.readdirSync(i, { withFileTypes: true }),
+        d => d.isDirectory() ? [] : [path.join(i, d.name)]
+      )
+    }
+  )
+  */
+
+  for (const swagger of [
+    // tslint:disable-next-line:max-line-length
+    "C:/github.com/Azure/azure-rest-api-specs/specification/logic/resource-manager/Microsoft.Logic/preview/2018-07-01-preview/logic.json"
+  ]) {
+    try {
+      await oav.validateExamples(swagger, undefined, {consoleLogLevel: 'error', pretty: true});
+      oav.clearCache();
+    } catch (e) {
+      // tslint:disable-next-line:no-console
+      console.error("error: ")
+      // tslint:disable-next-line:no-console
+      console.error(e)
+    }
+  }
+}
+
+const x = f()
+
+// tslint:disable-next-line:no-console
+console.log(x)

--- a/test/errorInfoTests.ts
+++ b/test/errorInfoTests.ts
@@ -6,16 +6,22 @@ import * as assert from "assert"
 
 describe("error info", () => {
   it("error info should contain url to file", async () => {
-    const result = await validateExamples(
-      "./test/modelValidation/swaggers/specification/errorInfo/apimusers.json",
-      undefined,
-      {
-        consoleLogLevel: "off"
-      }
-    )
-    assert.strictEqual(result.length, 2)
-    const r = result[0].errorDetails as any
-    assert.strictEqual(
-      r.url, "./test/modelValidation/swaggers/specification/errorInfo/apimusers.json")
+    try {
+      const result = await validateExamples(
+        "./test/modelValidation/swaggers/specification/errorInfo/apimusers.json",
+        undefined,
+        {
+          consoleLogLevel: "off"
+        }
+      )
+      assert.strictEqual(result.length, 2)
+      const r = result[0].errorDetails as any
+      assert.strictEqual(
+        r.url,
+        "./test/modelValidation/swaggers/specification/errorInfo/apimusers.json"
+      )
+    } catch (e) {
+      assert.fail(e)
+    }
   })
 })


### PR DESCRIPTION
Issue #271 