### PR TITLE
Add live validator init time docs cache

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 03/06/2019 0.14.1
+
+- Add doc cache during `LiveValidator initialization` to reduce memory footprint and execution time.
+
 ### 03/06/2019 0.14.0
 
 - Remove package level global doc cache.

--- a/lib/util/jsonUtils.ts
+++ b/lib/util/jsonUtils.ts
@@ -14,6 +14,7 @@ import { SwaggerObject } from "yasway"
 import { log } from "./logging"
 import { parseContent } from "./makeRequest"
 import { isSubPath, splitPathAndReverse } from "./path"
+import { DocCache } from './documents';
 
 const setSuppression = (
   info: FilePosition | undefined,
@@ -39,8 +40,14 @@ const setSuppression = (
 export async function parseJson(
   suppression: Suppression | undefined,
   specPath: string,
-  reportError: jsonParser.ReportError
+  reportError: jsonParser.ReportError,
+  docsCache?: DocCache
 ): Promise<SwaggerObject> {
+
+  const doc = docsCache && docsCache[specPath]
+  if (doc) {
+    return await doc
+  }
 
   const getSuppressionArray = (
     suppressionItems: ReadonlyArray<SuppressionItem>
@@ -109,6 +116,10 @@ export async function parseJson(
   }
 
   const swaggerObjectPromise = createSwaggerObject()
+
+  if (docsCache) {
+    docsCache[specPath] = swaggerObjectPromise
+  }
 
   return swaggerObjectPromise
 }

--- a/lib/validators/specResolver.ts
+++ b/lib/validators/specResolver.ts
@@ -35,6 +35,7 @@ import { Suppression } from "@azure/openapi-markdown"
 import * as jsonUtils from "../util/jsonUtils"
 import * as jsonParser from "@ts-common/json-parser"
 import * as ps from "@ts-common/property-set"
+import { DocCache } from '../util/documents';
 
 const ErrorCodes = C.ErrorCodes
 
@@ -113,7 +114,8 @@ export class SpecResolver {
     specPath: string,
     specInJson: SwaggerObject,
     options: Options,
-    private readonly reportError: jsonParser.ReportError
+    private readonly reportError: jsonParser.ReportError,
+    private readonly docsCache: DocCache = {}
   ) {
     if (
       specPath === null ||
@@ -229,7 +231,7 @@ export class SpecResolver {
       if (this.options.shouldResolveNullableTypes) {
         this.resolveNullableTypes()
       }
-     } catch (err) {
+    } catch (err) {
       const e = {
         message: "internal error: " + err.message,
         code: ErrorCodes.InternalError.name,
@@ -379,7 +381,7 @@ export class SpecResolver {
       docPath = utils.joinPath(docDir, parsedReference.filePath)
     }
 
-    const result = await jsonUtils.parseJson(suppression, docPath, this.reportError)
+    const result = await jsonUtils.parseJson(suppression, docPath, this.reportError, this.docsCache)
     if (!parsedReference.localReference) {
       // Since there is no local reference we will replace the key in the object with the parsed
       // json (relative) file it is referring to.
@@ -930,7 +932,7 @@ export class SpecResolver {
       if (d) {
         const required = definition.required
         if (!isArray(required)) {
-          definition.required = [ discriminator ]
+          definition.required = [discriminator]
         } else if (required.find(v => v === discriminator) === undefined) {
           definition.required = [...required, discriminator]
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
- use a docs cache for live validation to reduce memory footprint and execution time