### PR TITLE
Use one cache validator per SpecValidator

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 03/06/2019 0.14.2
+
+- Use one cache per SpecValidator inside the LiveValidator.
+
 ### 03/06/2019 0.14.1
 
 - Add doc cache during `LiveValidator initialization` to reduce memory footprint and execution time.

--- a/lib/validators/liveValidator.ts
+++ b/lib/validators/liveValidator.ts
@@ -18,7 +18,6 @@ import { PotentialOperationsResult } from "../models/potentialOperationsResult"
 import { Operation, Request } from "yasway"
 import { ParsedUrlQuery } from "querystring"
 import { MutableStringMap } from "@ts-common/string-map"
-import { DocCache } from '../util/documents';
 
 export interface Options {
   swaggerPaths: string[]
@@ -202,9 +201,8 @@ export class LiveValidator {
     //   }
     //   ...
     // }
-    const docsCache: DocCache = {}
     const promiseFactories = swaggerPaths.map(swaggerPath => async () =>
-      await this.getSwaggerInitializer(swaggerPath, docsCache)
+      await this.getSwaggerInitializer(swaggerPath)
     )
 
     await utils.executePromisesSequentially(promiseFactories)
@@ -648,12 +646,12 @@ export class LiveValidator {
     }
   }
 
-  private async getSwaggerInitializer(swaggerPath: string, docsCache: DocCache): Promise<void> {
+  private async getSwaggerInitializer(swaggerPath: string): Promise<void> {
     log.info(`Building cache from: "${swaggerPath}"`)
 
     const validator = new SpecValidator(swaggerPath, null, {
       isPathCaseSensitive: this.options.isPathCaseSensitive
-    }, docsCache)
+    })
 
     try {
       const api = await validator.initialize()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
Hitting the issue here if we share the docs cache https://github.com/Azure/oav/issues/395