### PR TITLE
Base model discriminator value fix.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 02/05/2020 0.20.7
+- Add base model name as a value to discriminator enum value list.[Issue#468](https://github.com/Azure/oav/issues/468)
+
 ## 01/16/2020 0.20.6
 - security vulnerability fix for handlebars, kind-of and lodash
 

--- a/lib/validators/specResolver.ts
+++ b/lib/validators/specResolver.ts
@@ -348,6 +348,10 @@ export class SpecResolver {
     const docDir = path.dirname(docPath)
 
     if (parsedReference.filePath) {
+      const regexFilePath = new RegExp("^[.\\w\\\\\\/].*.[A-Za-z]+$")
+      if (!regexFilePath.test(parsedReference.filePath)) {
+        throw new Error(`${node.$ref} isn't a valid local reference file.`)
+      }
       // assuming that everything in the spec is relative to it, let us join the spec directory
       // and the file path in reference.
       docPath = utils.joinPath(docDir, parsedReference.filePath)
@@ -453,12 +457,12 @@ export class SpecResolver {
         this.reportError,
         this.docsCache
       )
-      const result2: any = result
-      result2.docPath = docPath
+      const resultWithReferenceDocPath: any = result
+      resultWithReferenceDocPath.docPath = docPath
 
       // We set a function `() => result` instead of an object `result` to avoid
       // reference resolution in the examples.
-      utils.setObject(doc as {}, slicedRefName, () => result2)
+      utils.setObject(doc as {}, slicedRefName, () => resultWithReferenceDocPath)
     } else {
       if (jsonPointer.has(doc as {}, slicedRefName)) {
         jsonPointer.remove(doc as {}, slicedRefName)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
[Issue#468](https://github.com/Azure/oav/issues/468)
Previously for polymorphic case, the discriminator value was set to
model name in case of base model. It should also keep original enum
values which is used in model validation. So this fix is to keep
original enum values then add base model as first element in the enum
values list.
The reason to put base model name as first element is the first element
is used to match the discriminator value of polymorphic models and for
base model case the discriminator should be base model name.