### PR TITLE
Base model discriminator value fix.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 02/05/2020 0.20.7
+- Add base model name as a value to discriminator enum value list.[Issue#468](https://github.com/Azure/oav/issues/468)
+
 ## 01/16/2020 0.20.6
 - security vulnerability fix for handlebars, kind-of and lodash
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "0.20.6",
+  "version": "0.20.7",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/test/modelValidation/swaggers/specification/polymorphicBaseModelDiscriminator/examples/UpdateOperation.json
+++ b/test/modelValidation/swaggers/specification/polymorphicBaseModelDiscriminator/examples/UpdateOperation.json
@@ -1,0 +1,14 @@
+{
+  "parameters": {
+    "parameters": {
+      "dType": "typeA"
+    }
+  },
+  "responses": {
+    "200": {
+      "body": {
+        "dType": "typeA"
+      }
+    }
+  }
+}

--- a/test/modelValidation/swaggers/specification/polymorphicBaseModelDiscriminator/spec.json
+++ b/test/modelValidation/swaggers/specification/polymorphicBaseModelDiscriminator/spec.json
@@ -1,0 +1,62 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "some title",
+    "version": "2099-11-11"
+  },
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "definitions": {
+    "A": {
+      "title": "yeah",
+      "discriminator": "dType",
+      "properties": {
+        "dType": {
+          "title": "d property",
+          "enum": ["typeA", "typeB"],
+          "x-ms-enum": {
+            "name": "someName",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "B": {
+      "title": "no",
+      "x-ms-discriminator-value": "typeB",
+      "allOf": [{ "$ref": "#/definitions/A" }]
+    }
+  },
+  "paths": {
+    "/providers/operations": {
+      "put": {
+        "description": "get something",
+        "operationId": "Update_Operation",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/A"
+            },
+            "description": "The parameters of the rule to create or update."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "a",
+            "schema": {
+              "$ref": "#/definitions/A"
+            }
+          }
+        },
+        "x-ms-examples": {
+          "Activity_List": {
+            "$ref": "./examples/UpdateOperation.json"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/modelValidatorTests.ts
+++ b/test/modelValidatorTests.ts
@@ -581,4 +581,14 @@ describe("Model Validation", () => {
       assert.strictEqual(result.length, 0)
     })
   })
+
+  describe("Base polymorphic model", () => {
+    it("Should have origin enum values and base model name as discriminator values list", async () => {
+      const specPath2 = `${testPath}/modelValidation/swaggers/specification/polymorphicBaseModelDiscriminator/spec.json`
+      const result = await validate.validateExamples(specPath2, undefined, {
+        consoleLogLevel: "off"
+      })
+      assert.strictEqual(result.length, 0)
+    })
+  })
 })


### PR DESCRIPTION
[Issue#468](https://github.com/Azure/oav/issues/468)
Previously for polymorphic case, the discriminator value was set to
model name in case of base model. It should also keep original enum
values which is used in model validation. So this fix is to keep
original enum values then add base model as first element in the enum
values list.
The reason to put base model name as first element is the first element
is used to match the discriminator value of polymorphic models and for
base model case the discriminator should be base model name.
Added a unit test for this change.