### PR TITLE
User/raychen/lro

### DIFF
--- a/.ci/validate-examples-regression.yml
+++ b/.ci/validate-examples-regression.yml
@@ -3,6 +3,7 @@ pool:
 
 trigger:
   - master
+  - develop
 
 pr:
   branches:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Change Log - oav
 
+## 02/08/2021 2.2.7
+
+- Add new rules of 'LRO_RESPONSE_HEADER' and 'LRO_RESPONSE_CODE'.
+- Add option of 'isArmCall' to differentiate rulesets for Arm and RpaaS in validation apis.
+
 ## 03/12/2021 2.2.6
 
 - Fixed the mock value of 'location' header and 'azure_AsyncOperation' header.

--- a/lib/liveValidation/liveValidator.ts
+++ b/lib/liveValidation/liveValidator.ts
@@ -85,6 +85,7 @@ interface Meta {
 export interface ValidateOptions {
   readonly includeErrors?: ExtendedErrorCode[];
   readonly includeOperationMatch?: boolean;
+  isArmCall?: boolean
 }
 
 export enum LiveValidatorLoggingLevels {
@@ -383,7 +384,8 @@ export class LiveValidator {
         liveResponse,
         info,
         this.loader,
-        options.includeErrors
+        options.includeErrors,
+        options.isArmCall,
       );
     } catch (resValidationError) {
       const msg =

--- a/lib/liveValidation/liveValidator.ts
+++ b/lib/liveValidation/liveValidator.ts
@@ -85,7 +85,7 @@ interface Meta {
 export interface ValidateOptions {
   readonly includeErrors?: ExtendedErrorCode[];
   readonly includeOperationMatch?: boolean;
-  isArmCall?: boolean
+  isArmCall?: boolean;
 }
 
 export enum LiveValidatorLoggingLevels {
@@ -385,7 +385,7 @@ export class LiveValidator {
         info,
         this.loader,
         options.includeErrors,
-        options.isArmCall,
+        options.isArmCall
       );
     } catch (resValidationError) {
       const msg =

--- a/lib/liveValidation/operationValidator.ts
+++ b/lib/liveValidation/operationValidator.ts
@@ -127,7 +127,7 @@ export const validateSwaggerLiveResponse = async (
   const headers = transformLiveHeader(response.headers ?? {}, rsp);
   if (rsp.schema !== undefined) {
     validateContentType(operation.produces!, headers, false, result);
-    if (isArmCall) {
+    if (isArmCall && realCode >= 200 && realCode < 300) {
       validateLroOperation(operation, statusCode, headers, result);
     }
   }

--- a/lib/swagger/swaggerTypes.ts
+++ b/lib/swagger/swaggerTypes.ts
@@ -14,6 +14,8 @@ import {
   xmsSkipUrlEncoding,
   xNullable,
   xmsAzureResource,
+  xmsLongRunningOperationOptions,
+  xmsLongRunningOperationOptionsField,
 } from "../util/constants";
 import { $id } from "./jsonLoader";
 
@@ -143,6 +145,7 @@ export interface Operation {
   security?: Security[];
   tags?: string[];
   [xmsLongRunningOperation]?: boolean;
+  [xmsLongRunningOperationOptions]?: { [xmsLongRunningOperationOptionsField]: string };
   [xmsExamples]?: { [description: string]: SwaggerExample };
 
   // TODO check why do we need provider

--- a/lib/swaggerValidator/schemaValidator.ts
+++ b/lib/swaggerValidator/schemaValidator.ts
@@ -52,7 +52,7 @@ export const validateErrorMessages: { [key in ExtendedErrorCode]?: (params: any)
   INVALID_RESPONSE_BODY: strTemplate`Body is required in response but not provided`,
   INVALID_RESPONSE_HEADER: strTemplate`Header ${"missingProperty"} is required in response but not provided`,
   MISSING_RESOURCE_ID: strTemplate`id is required to return in response of GET/PUT resource calls but not provided`,
-  LRO_RESPONSE_CODE: strTemplate`Patch/Delete/Post long running operation should return 202 but ${"statusCode"} returned`,
+  LRO_RESPONSE_CODE: strTemplate`Patch/Post long running operation must return 201 or 202, Delete long running operation must return 202 or 204, Put long running operation must return 202 or 201 or 200, but ${"statusCode"} returned`,
   LRO_RESPONSE_HEADER: strTemplate`Long running operation should return ${"header"} in header but not provided`,
 
   DISCRIMINATOR_VALUE_NOT_FOUND: strTemplate`Discriminator value "${"data"}" not found`,

--- a/lib/swaggerValidator/schemaValidator.ts
+++ b/lib/swaggerValidator/schemaValidator.ts
@@ -52,6 +52,8 @@ export const validateErrorMessages: { [key in ExtendedErrorCode]?: (params: any)
   INVALID_RESPONSE_BODY: strTemplate`Body is required in response but not provided`,
   INVALID_RESPONSE_HEADER: strTemplate`Header ${"missingProperty"} is required in response but not provided`,
   MISSING_RESOURCE_ID: strTemplate`id is required to return in response of GET/PUT resource calls but not provided`,
+  LRO_RESPONSE_CODE: strTemplate`Patch/Delete/Post long running operation should return 202 but ${"statusCode"} returned`,
+  LRO_RESPONSE_HEADER: strTemplate`Long running operation should return ${"header"} in header but not provided`,
 
   DISCRIMINATOR_VALUE_NOT_FOUND: strTemplate`Discriminator value "${"data"}" not found`,
   ANY_OF_MISSING: strTemplate`Data does not match any schemas from 'anyOf'`,

--- a/lib/util/constants.ts
+++ b/lib/util/constants.ts
@@ -13,6 +13,10 @@ export const xmsSkipUrlEncoding = "x-ms-skip-url-encoding";
 
 export const xmsLongRunningOperation = "x-ms-long-running-operation";
 
+export const xmsLongRunningOperationOptions = "x-ms-long-running-operation-options";
+
+export const xmsLongRunningOperationOptionsField = "final-state-via";
+
 export const xmsDiscriminatorValue = "x-ms-discriminator-value";
 
 export const xmsEnum = "x-ms-enum";

--- a/lib/util/validationError.ts
+++ b/lib/util/validationError.ts
@@ -82,6 +82,8 @@ const errorConstants = {
   INVALID_RESPONSE_HEADER: { severity: Severity.Error, docUrl: "" },
   INVALID_RESPONSE_BODY: { severity: Severity.Critical, docUrl: "" },
   MISSING_RESOURCE_ID: { severity: Severity.Critical, docUrl: "" },
+  LRO_RESPONSE_CODE: { severity: Severity.Critical, docUrl: "" },
+  LRO_RESPONSE_HEADER: { severity: Severity.Critical, docUrl: "" },
 };
 
 const wrapperErrorConstants = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/test/__snapshots__/liveValidatorTests.ts.snap
+++ b/test/__snapshots__/liveValidatorTests.ts.snap
@@ -46,6 +46,86 @@ Object {
 }
 `;
 
+exports[`Live Validator Initialize cache and validate should report error in response when response code isn't correct in case of long running operation 1`] = `
+Object {
+  "requestValidationResult": Object {
+    "errors": Array [],
+    "isSuccessful": true,
+    "operationInfo": Object {
+      "apiVersion": "2021-01-01-privatepreview",
+      "operationId": "Linker_Update",
+    },
+    "runtimeException": undefined,
+  },
+  "responseValidationResult": Object {
+    "errors": Array [
+      Object {
+        "code": "LRO_RESPONSE_CODE",
+        "documentationUrl": "",
+        "jsonPathsInPayload": Array [],
+        "message": "Patch/Post long running operation must return 201 or 202, Delete long running operation must return 202 or 204, Put long running operation must return 202 or 201 or 200, but 200 returned",
+        "pathsInPayload": Array [],
+        "schemaPath": "",
+        "severity": 0,
+        "source": Object {
+          "position": Object {
+            "column": 22,
+            "line": 300,
+          },
+          "url": "specification/servicelinker/resource-manager/Microsoft.ServiceLinker/preview/2021-01-01-privatepreview/servicelinker.json",
+        },
+      },
+    ],
+    "isSuccessful": false,
+    "operationInfo": Object {
+      "apiVersion": "2021-01-01-privatepreview",
+      "operationId": "Linker_Update",
+    },
+    "runtimeException": undefined,
+  },
+}
+`;
+
+exports[`Live Validator Initialize cache and validate should report error when LRO header is not returned in response in case of long running operation 1`] = `
+Object {
+  "requestValidationResult": Object {
+    "errors": Array [],
+    "isSuccessful": true,
+    "operationInfo": Object {
+      "apiVersion": "2021-01-01-privatepreview",
+      "operationId": "Linker_CreateOrUpdate",
+    },
+    "runtimeException": undefined,
+  },
+  "responseValidationResult": Object {
+    "errors": Array [
+      Object {
+        "code": "LRO_RESPONSE_HEADER",
+        "documentationUrl": "",
+        "jsonPathsInPayload": Array [],
+        "message": "Long running operation should return location or azure-AsyncOperation in header but not provided",
+        "pathsInPayload": Array [],
+        "schemaPath": "",
+        "severity": 0,
+        "source": Object {
+          "position": Object {
+            "column": 22,
+            "line": 177,
+          },
+          "url": "specification/servicelinker/resource-manager/Microsoft.ServiceLinker/preview/2021-01-01-privatepreview/servicelinker.json",
+        },
+      },
+    ],
+    "isSuccessful": false,
+    "operationInfo": Object {
+      "apiVersion": "2021-01-01-privatepreview",
+      "operationId": "Linker_CreateOrUpdate",
+    },
+    "runtimeException": undefined,
+  },
+}
+`;
+
 exports[`Live Validator Initialize cache and validate should return no errors for valid input with optional parameter body empty 1`] = `
 Object {
   "requestValidationResult": Object {

--- a/test/liveValidation/payloads/lro_responsecode_error_input.json
+++ b/test/liveValidation/payloads/lro_responsecode_error_input.json
@@ -1,0 +1,53 @@
+{
+  "liveRequest": {
+    "headers": {
+      "strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "x-ms-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "x-ms-correlation-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "date": "Tue, 11 Sep 2018 19:00:21 GMT",
+      "eTag": "\"AAAAAAAAQqUAAAAAAABCpw==\"",
+      "server": "Microsoft-HTTPAPI/2.0",
+      "Content-Type": "application/json"
+    },
+    "method": "PATCH",
+    "url": "/subscriptions/937bc588-a144-4083-8612-5f9ffbbddb14/resourceGroups/canaryrg/providers/Microsoft.Web/sites/canarywebapp/providers/Microsoft.ServiceLinker/linkers/SpiderMan?api-version=2021-01-01-privatepreview",
+    "body": {
+      "properties": {
+        "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DocumentDb/databaseAccounts/test-acc/mongodbDatabases/test-db",
+        "authInfo": {
+          "authType": "servicePrincipal",
+          "name": "name",
+          "id": "id"
+        }
+      }
+    },
+    "query": {
+      "api-version": "2021-01-01-privatepreview"
+    }
+  },
+  "liveResponse": {
+    "statusCode": "200",
+    "headers": {
+      "strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "x-ms-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "x-ms-correlation-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "date": "Tue, 11 Sep 2018 19:00:21 GMT",
+      "eTag": "\"AAAAAAAAQqUAAAAAAABCpw==\"",
+      "server": "Microsoft-HTTPAPI/2.0",
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/sites/test-app/providers/Microsoft.ServiceLinker/links/linkName",
+      "type": "Microsoft.ServiceLinker/links",
+      "name": "linkName",
+      "properties": {
+        "authInfo": {
+          "authType": "servicePrincipal",
+          "name": "name",
+          "id": "id"
+        },
+        "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DocumentDb/databaseAccounts/test-acc/mongodbDatabases/test-db"
+      }
+    }
+  }
+}

--- a/test/liveValidation/payloads/lro_responseheader_error_input.json
+++ b/test/liveValidation/payloads/lro_responseheader_error_input.json
@@ -1,0 +1,51 @@
+{
+  "liveRequest": {
+    "headers": {
+      "strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "x-ms-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "x-ms-correlation-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "date": "Tue, 11 Sep 2018 19:00:21 GMT",
+      "eTag": "\"AAAAAAAAQqUAAAAAAABCpw==\"",
+      "server": "Microsoft-HTTPAPI/2.0",
+      "Content-Type": "application/json"
+    },
+    "method": "PUT",
+    "url": "/subscriptions/937bc588-a144-4083-8612-5f9ffbbddb14/resourceGroups/canaryrg/providers/Microsoft.Web/sites/canarywebapp/providers/Microsoft.ServiceLinker/linkers/SpiderMan?api-version=2021-01-01-privatepreview",
+    "body": {
+      "properties": {
+        "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DocumentDb/databaseAccounts/test-acc/mongodbDatabases/test-db",
+        "authInfo": {
+          "authType": "secret",
+          "name": "name",
+          "secret": "secret"
+        }
+      }
+    },
+    "query": {
+      "api-version": "2021-01-01-privatepreview"
+    }
+  },
+  "liveResponse": {
+    "statusCode": "201",
+    "headers": {
+      "strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "x-ms-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "x-ms-correlation-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "date": "Tue, 11 Sep 2018 19:00:21 GMT",
+      "eTag": "\"AAAAAAAAQqUAAAAAAABCpw==\"",
+      "server": "Microsoft-HTTPAPI/2.0",
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "type": "Microsoft.ServiceLinker/links",
+      "name": "linkName",
+      "properties": {
+        "authInfo": {
+          "authType": "secret",
+          "name": "name"
+        },
+        "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DocumentDb/databaseAccounts/test-acc/mongodbDatabases/test-db"
+      }
+    }
+  }
+}

--- a/test/liveValidatorTests.ts
+++ b/test/liveValidatorTests.ts
@@ -738,6 +738,49 @@ describe("Live Validator", () => {
       expect(validationResult).toMatchSnapshot();
     });
 
+    it(`should report error in response when response code isn't correct in case of long running operation`, async () => {
+      const options = {
+        directory: `${__dirname}/liveValidation/swaggers/`,
+        isPathCaseSensitive: false,
+        useRelativeSourceLocationUrl: true,
+        swaggerPathsPattern: [
+          "specification\\servicelinker\\resource-manager\\Microsoft.ServiceLinker\\**\\*.json",
+        ],
+        git: {
+          shouldClone: false,
+        },
+        isArmCall: true,
+      };
+      const liveValidator = new LiveValidator(options);
+      await liveValidator.initialize();
+      const payload = require(`${__dirname}/liveValidation/payloads/lro_responsecode_error_input.json`);
+      const validationResult = await liveValidator.validateLiveRequestResponse(payload, {
+        isArmCall: true,
+      });
+      expect(validationResult).toMatchSnapshot();
+    });
+
+    it(`should report error when LRO header is not returned in response in case of long running operation`, async () => {
+      const options = {
+        directory: `${__dirname}/liveValidation/swaggers/`,
+        isPathCaseSensitive: false,
+        useRelativeSourceLocationUrl: true,
+        swaggerPathsPattern: [
+          "specification\\servicelinker\\resource-manager\\Microsoft.ServiceLinker\\**\\*.json",
+        ],
+        git: {
+          shouldClone: false,
+        },
+      };
+      const liveValidator = new LiveValidator(options);
+      await liveValidator.initialize();
+      const payload = require(`${__dirname}/liveValidation/payloads/lro_responseheader_error_input.json`);
+      const validationResult = await liveValidator.validateLiveRequestResponse(payload, {
+        isArmCall: true,
+      });
+      expect(validationResult).toMatchSnapshot();
+    });
+
     it(`should return no errors for valid input with optional parameter body null`, async () => {
       const options = {
         directory: `${__dirname}/liveValidation/swaggers/`,


### PR DESCRIPTION
Add new rules of 'LRO_RESPONSE_HEADER' and 'LRO_RESPONSE_CODE'.
Add option of 'isArmCall' to differentiate rulesets for Arm and RpaaS in validation apis.

See [document](https://github.com/Azure/azure-rest-api-specs/pull/13416) of these two rules for details. 