### PR TITLE
Ignore LRO header check in case of sync calls

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,14 +1,18 @@
 # Change Log - oav
 
-## 6/25 2021 2.5.8
+## 07/05/2021 2021 2.5.9
+
+- Ignore LRO_RESPONSE_HEADER rule check in case of synchronous api call
+
+## 06/25/2021 2021 2.5.8
 
 - support extract armTemplate deployment output to variables
 
-## 6/22 2021 2.5.7
+## 06/22/2021 2021 2.5.7
 
 - small fix for passing validation-level
 
-## 6/22 2021 2.5.6
+## 06/22/2021 2021 2.5.6
 
 - optimise validation logical. Ignore readonly and secret property response check
 - DO NOT output log when request method is POST

--- a/lib/liveValidation/operationValidator.ts
+++ b/lib/liveValidation/operationValidator.ts
@@ -325,7 +325,7 @@ const validateLroOperation = (
   operation: Operation,
   statusCode: string,
   headers: StringMap<string>,
-  body: StringMap<unknown> | undefined,
+  body: any,
   result: LiveValidationIssue[]
 ) => {
   if (operation["x-ms-long-running-operation"] === true) {
@@ -361,11 +361,11 @@ const validateLroHeader = (
   operation: Operation,
   statusCode: string,
   headers: StringMap<string>,
-  body: StringMap<unknown> | undefined,
+  body: any,
   result: LiveValidationIssue[]
 ) => {
-  if (statusCode === "201" && body?.["properties"] !== undefined) {
-    const properties = body.properties as any;
+  if (statusCode === "201" && body?.properties !== undefined) {
+    const properties = body.properties;
     if (
       properties &&
       (properties.provisioningState === undefined ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3334,7 +3334,7 @@
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
@@ -4168,7 +4168,7 @@
     },
     "difflib": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/difflib/-/difflib-0.2.4.tgz",
       "integrity": "sha1-teMDYabbAjF21WKJLbhZQKcY9H4=",
       "requires": {
         "heap": ">= 0.2.0"
@@ -5929,7 +5929,7 @@
     },
     "heap": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.6.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/heap/-/heap-0.2.6.tgz",
       "integrity": "sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw="
     },
     "hosted-git-info": {
@@ -10175,12 +10175,12 @@
     },
     "lodash.includes": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
     },
     "lodash.isequal": {
@@ -10190,22 +10190,22 @@
     },
     "lodash.isinteger": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isnumber": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.isstring": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
     },
     "lodash.merge": {
@@ -10221,7 +10221,7 @@
     },
     "lodash.once": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
@@ -11218,7 +11218,7 @@
     },
     "object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
@@ -11998,7 +11998,7 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "https://pkgs.dev.azure.com/devdiv/_packaging/openapi-platform/npm/registry/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/test/__snapshots__/liveValidatorTests.ts.snap
+++ b/test/__snapshots__/liveValidatorTests.ts.snap
@@ -23,6 +23,29 @@ Object {
 }
 `;
 
+exports[`Live Validator Initialize cache and validate should not report error when LRO header is not returned in response in case of sync call 1`] = `
+Object {
+  "requestValidationResult": Object {
+    "errors": Array [],
+    "isSuccessful": true,
+    "operationInfo": Object {
+      "apiVersion": "2021-01-01-privatepreview",
+      "operationId": "Linker_CreateOrUpdate",
+    },
+    "runtimeException": undefined,
+  },
+  "responseValidationResult": Object {
+    "errors": Array [],
+    "isSuccessful": true,
+    "operationInfo": Object {
+      "apiVersion": "2021-01-01-privatepreview",
+      "operationId": "Linker_CreateOrUpdate",
+    },
+    "runtimeException": undefined,
+  },
+}
+`;
+
 exports[`Live Validator Initialize cache and validate should report error in response for GET/PUT resource calls when id is not returned 1`] = `
 Object {
   "requestValidationResult": Object {

--- a/test/liveValidation/payloads/lro_responseheader_error_input.json
+++ b/test/liveValidation/payloads/lro_responseheader_error_input.json
@@ -44,6 +44,7 @@
           "authType": "secret",
           "name": "name"
         },
+        "provisioningState": "Processing",
         "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DocumentDb/databaseAccounts/test-acc/mongodbDatabases/test-db"
       }
     }

--- a/test/liveValidation/payloads/lro_responseheader_ignore_input.json
+++ b/test/liveValidation/payloads/lro_responseheader_ignore_input.json
@@ -1,0 +1,53 @@
+{
+  "liveRequest": {
+    "headers": {
+      "strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "x-ms-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "x-ms-correlation-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "date": "Tue, 11 Sep 2018 19:00:21 GMT",
+      "eTag": "\"AAAAAAAAQqUAAAAAAABCpw==\"",
+      "server": "Microsoft-HTTPAPI/2.0",
+      "Content-Type": "application/json"
+    },
+    "method": "PUT",
+    "url": "/subscriptions/937bc588-a144-4083-8612-5f9ffbbddb14/resourceGroups/canaryrg/providers/Microsoft.Web/sites/canarywebapp/providers/Microsoft.ServiceLinker/linkers/SpiderMan?api-version=2021-01-01-privatepreview",
+    "body": {
+      "properties": {
+        "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DocumentDb/databaseAccounts/test-acc/mongodbDatabases/test-db",
+        "authInfo": {
+          "authType": "secret",
+          "name": "name",
+          "secret": "secret"
+        }
+      }
+    },
+    "query": {
+      "api-version": "2021-01-01-privatepreview"
+    }
+  },
+  "liveResponse": {
+    "statusCode": "201",
+    "headers": {
+      "strict-Transport-Security": "max-age=31536000; includeSubDomains",
+      "x-ms-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "x-ms-correlation-request-id": "97856fec-304a-4317-87f0-f04c328402d3",
+      "date": "Tue, 11 Sep 2018 19:00:21 GMT",
+      "eTag": "\"AAAAAAAAQqUAAAAAAABCpw==\"",
+      "server": "Microsoft-HTTPAPI/2.0",
+      "Content-Type": "application/json"
+    },
+    "body": {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Web/sites/test-app/providers/Microsoft.ServiceLinker/links/linkName",
+      "type": "Microsoft.ServiceLinker/links",
+      "name": "linkName",
+      "properties": {
+        "authInfo": {
+          "authType": "secret",
+          "name": "name"
+        },
+        "provisioningState": "Succeeded",
+        "targetId": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.DocumentDb/databaseAccounts/test-acc/mongodbDatabases/test-db"
+      }
+    }
+  }
+}

--- a/test/liveValidatorTests.ts
+++ b/test/liveValidatorTests.ts
@@ -798,6 +798,26 @@ describe("Live Validator", () => {
       expect(validationResult).toMatchSnapshot();
     });
 
+    it(`should not report error when LRO header is not returned in response in case of sync call`, async () => {
+      const options = {
+        directory: `${__dirname}/liveValidation/swaggers/`,
+        isPathCaseSensitive: false,
+        useRelativeSourceLocationUrl: true,
+        swaggerPathsPattern: [
+          "specification\\servicelinker\\resource-manager\\Microsoft.ServiceLinker\\**\\*.json",
+        ],
+        git: {
+          shouldClone: false,
+        },
+        isArmCall: true,
+      };
+      const liveValidator = new LiveValidator(options);
+      await liveValidator.initialize();
+      const payload = require(`${__dirname}/liveValidation/payloads/lro_responseheader_ignore_input.json`);
+      const validationResult = await liveValidator.validateLiveRequestResponse(payload);
+      expect(validationResult).toMatchSnapshot();
+    });
+
     it(`should return no errors for valid input with optional parameter body null`, async () => {
       const options = {
         directory: `${__dirname}/liveValidation/swaggers/`,


### PR DESCRIPTION
If the api call is sync call, then the response header won't have LRO headers.