### PR TITLE
JSON-format traffic validation errors before printing

### DIFF
--- a/lib/report/generateReport.ts
+++ b/lib/report/generateReport.ts
@@ -451,8 +451,8 @@ export class ReportGenerator {
     const general_errors = view.getGeneralErrors();
     const runtime_errors = view.getRunTimeErrors();
 
-    console.log(general_errors);
-    console.log(runtime_errors);
+    console.log(JSON.stringify(general_errors, null, 2));
+    console.log(JSON.stringify(runtime_errors, null, 2));
 
     const text = Mustache.render(template, view);
     fs.writeFileSync(this.reportPath, text, "utf-8");


### PR DESCRIPTION
This is a tiny change to JSON format the general errors and runtime errors detected in a validate-traffic request.

Fixes #874 