### PR TITLE
Remove incorrect ASCII conversion

### DIFF
--- a/lib/swaggerValidator/ajv.ts
+++ b/lib/swaggerValidator/ajv.ts
@@ -125,7 +125,7 @@ export const ajvEnableByteFormat = (ajv: Ajv) => {
   ajv.addFormat("byte", {
     type: "string",
     validate: (x) => {
-      const decodedValue = Buffer.from(x, "base64").toString("ascii");
+      const decodedValue = Buffer.from(x, "base64");
       const reencodedValue = Buffer.from(decodedValue).toString("base64");
       return reencodedValue === x;
     },

--- a/regression/__snapshots__/validateExamplesRegression_latestOnly.test.ts.snap
+++ b/regression/__snapshots__/validateExamplesRegression_latestOnly.test.ts.snap
@@ -15027,63 +15027,6 @@ Array [
   },
   Object {
     "code": "INVALID_FORMAT",
-    "exampleJsonPath": "$responses.200.body.kubeconfigs[0].value",
-    "examplePosition": Object {
-      "column": 22,
-      "line": 14,
-    },
-    "exampleUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-07-01/examples/ManagedClustersListClusterAdminCredentials.json",
-    "message": "Object didn't pass validation for format byte: credentialValue1",
-    "operationId": "ManagedClusters_ListClusterAdminCredentials",
-    "schemaJsonPath": "#/properties/value/format",
-    "schemaPosition": Object {
-      "column": 18,
-      "line": 4778,
-    },
-    "schemaUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-07-01/managedClusters.json",
-    "severity": 0,
-    "source": "response",
-  },
-  Object {
-    "code": "INVALID_FORMAT",
-    "exampleJsonPath": "$responses.200.body.kubeconfigs[0].value",
-    "examplePosition": Object {
-      "column": 22,
-      "line": 14,
-    },
-    "exampleUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-07-01/examples/ManagedClustersListClusterUserCredentials.json",
-    "message": "Object didn't pass validation for format byte: credentialValue1",
-    "operationId": "ManagedClusters_ListClusterUserCredentials",
-    "schemaJsonPath": "#/properties/value/format",
-    "schemaPosition": Object {
-      "column": 18,
-      "line": 4778,
-    },
-    "schemaUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-07-01/managedClusters.json",
-    "severity": 0,
-    "source": "response",
-  },
-  Object {
-    "code": "INVALID_FORMAT",
-    "exampleJsonPath": "$responses.200.body.kubeconfigs[0].value",
-    "examplePosition": Object {
-      "column": 22,
-      "line": 14,
-    },
-    "exampleUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-07-01/examples/ManagedClustersListClusterMonitoringUserCredentials.json",
-    "message": "Object didn't pass validation for format byte: credentialValue1",
-    "operationId": "ManagedClusters_ListClusterMonitoringUserCredentials",
-    "schemaJsonPath": "#/properties/value/format",
-    "schemaPosition": Object {
-      "column": 18,
-      "line": 4778,
-    },
-    "schemaUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/containerservice/resource-manager/Microsoft.ContainerService/stable/2022-07-01/managedClusters.json",
-    "severity": 0,
-    "source": "response",
-  },
-  Object {
-    "code": "INVALID_FORMAT",
     "exampleJsonPath": "$parameters.parameters",
     "examplePosition": Object {
       "column": 19,
@@ -21481,25 +21424,6 @@ Array [
   },
   Object {
     "code": "INVALID_FORMAT",
-    "exampleJsonPath": "$responses.200.body.value[1].properties.packageApplications[0].rawIcon",
-    "examplePosition": Object {
-      "column": 30,
-      "line": 80,
-    },
-    "exampleUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/stable/2021-07-12/examples/MsixImage_Expand_Post.json",
-    "message": "Object didn't pass validation for format byte: RawIcon1",
-    "operationId": "MsixImages_Expand",
-    "schemaJsonPath": "#/properties/rawIcon/format",
-    "schemaPosition": Object {
-      "column": 20,
-      "line": 3347,
-    },
-    "schemaUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/stable/2021-07-12/desktopvirtualization.json",
-    "severity": 0,
-    "source": "response",
-  },
-  Object {
-    "code": "INVALID_FORMAT",
     "exampleJsonPath": "$responses.200.body.value[1].properties.packageApplications[0].rawPng",
     "examplePosition": Object {
       "column": 29,
@@ -21512,25 +21436,6 @@ Array [
     "schemaPosition": Object {
       "column": 19,
       "line": 3352,
-    },
-    "schemaUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/stable/2021-07-12/desktopvirtualization.json",
-    "severity": 0,
-    "source": "response",
-  },
-  Object {
-    "code": "INVALID_FORMAT",
-    "exampleJsonPath": "$responses.200.body.value[1].properties.packageApplications[1].rawIcon",
-    "examplePosition": Object {
-      "column": 30,
-      "line": 89,
-    },
-    "exampleUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/stable/2021-07-12/examples/MsixImage_Expand_Post.json",
-    "message": "Object didn't pass validation for format byte: RawIcon2",
-    "operationId": "MsixImages_Expand",
-    "schemaJsonPath": "#/properties/rawIcon/format",
-    "schemaPosition": Object {
-      "column": 20,
-      "line": 3347,
     },
     "schemaUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/desktopvirtualization/resource-manager/Microsoft.DesktopVirtualization/stable/2021-07-12/desktopvirtualization.json",
     "severity": 0,
@@ -29269,25 +29174,6 @@ exports[`validateExamples should not regress for file '/home/vsts/work/1/s/regre
 
 exports[`validateExamples should not regress for file '/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/stable/2022-09-10/registeredidentities.json': returned results 1`] = `
 Array [
-  Object {
-    "code": "INVALID_FORMAT",
-    "exampleJsonPath": "$parameters.certificateRequest",
-    "examplePosition": Object {
-      "column": 27,
-      "line": 8,
-    },
-    "exampleUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/stable/2022-09-10/examples/PUTVaultCred.json",
-    "message": "Object didn't pass validation for format byte: MTTC3TCCAcWgAwIBAgIQEj9h+ZLlXK9KrqZX9UkAnzANBgkqhkiG9w0BAQUFADAeMRwwGgYDVQQDExNXaW5kb3dzIEF6dXJlIFRvb2xzMB4XDTE3MTIxODA5MTc1M1oXDTE3MTIyMzA5Mjc1M1owHjEcMBoGA1UEAxMTV2luZG93cyBBenVyZSBUb29sczCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAK773/eZZ69RbZZAT05r9MjUxu9y1L1Pn1EgPk62IPJyHlO3OZA922eSBahhP4bgmFljN4LVReqQ5eT/wqO0Zhc+yFkUy4U4RdbQLeUZt2W7yy9XLXgVvqeYDgsjg/QhHetgHArQBW+tlQq5+zPdU7zchI4rbShSJrWhLrZFWiOyFPsuAE4joUQHNlRifdCTsBGKk8HRCY3j1S3c4bfEn3zxlrvrXXssRuW5mJM95rMk0tskoRxXSCi6i9bnlki2Cs9mpVMmBFeofs41KwzlWU0TgpdD8s1QEdvfGB5NbByfetPX7MfJaTBeHZEGbv/Iq8l72u8sPBoOhcaH7qDE/mECAwEAAaMXMBUwEwYDVR0lBAwwCgYIKwYBBQUHAwIwDQYJKoZIhvcNAQEFBQADggEBAILfgHluye1Q+WelhgWhpBBdIq2C0btfV8eFsZaTlBUrM0fwpxQSlAWc2oYHVMQI4A5iUjbDOY35O4yc+TnWKDBKf+laqDP+yos4aiUPuadGUZfvDk7kuw7xeECs64JpHAIEKdRHFW9rD3gwG+nIWaDnEL/7rTyhL3kXrRW2MSUAL8g3GX8Z45c+MQY0jmASIqWdhGn1vpAGyA9mKkzsqg7FXjg8GZb24tGl5Ky85+ip4dkBfXinDD8WwaGyjhGGK97ErvNmN36qly/H0H1Qngiovg1FbHDmkcFO5QclnEJsFFmcO2CcHp5Fqh2wXn5O1cQaxCIRTpQ/uXRpDjl2wKs=",
-    "operationId": "VaultCertificates_Create",
-    "schemaJsonPath": "#/properties/certificate/format",
-    "schemaPosition": Object {
-      "column": 24,
-      "line": 151,
-    },
-    "schemaUrl": "/home/vsts/work/1/s/regression/azure-rest-api-specs/specification/recoveryservices/resource-manager/Microsoft.RecoveryServices/stable/2022-09-10/registeredidentities.json",
-    "severity": 0,
-    "source": "request",
-  },
   Object {
     "code": "INVALID_FORMAT",
     "exampleJsonPath": "$responses.200.body.properties.certificate",

--- a/test/__snapshots__/liveValidatorTests.ts.snap
+++ b/test/__snapshots__/liveValidatorTests.ts.snap
@@ -383,10 +383,10 @@ Object {
         "jsonPathsInPayload": Array [
           "$.properties.options[0].restriction.primaryVerificationKey.keyValue",
         ],
-        "message": "Object didn't pass validation for format byte: aaaaaaaaaaaaaaaaaaaaaaaa",
+        "message": "Object didn't pass validation for format byte: not valid base64",
         "params": Array [
           "byte",
-          "aaaaaaaaaaaaaaaaaaaaaaaa",
+          "not valid base64",
         ],
         "pathsInPayload": Array [
           "/properties/options/0/restriction/primaryVerificationKey/keyValue",
@@ -418,10 +418,10 @@ Object {
         "jsonPathsInPayload": Array [
           "$.properties.policyId",
         ],
-        "message": "Object didn't pass validation for format uuid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "message": "Object didn't pass validation for format uuid: not valid base64",
         "params": Array [
           "uuid",
-          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "not valid base64",
         ],
         "pathsInPayload": Array [
           "/properties/policyId",
@@ -492,10 +492,10 @@ Object {
         "jsonPathsInPayload": Array [
           "$.properties.options[0].restriction.primaryVerificationKey.keyValue",
         ],
-        "message": "Object didn't pass validation for format byte: aaaaaaaaaaaaaaaaaaaaaaaa",
+        "message": "Object didn't pass validation for format byte: not valid base64",
         "params": Array [
           "byte",
-          "aaaaaaaaaaaaaaaaaaaaaaaa",
+          "not valid base64",
         ],
         "pathsInPayload": Array [
           "/properties/options/0/restriction/primaryVerificationKey/keyValue",

--- a/test/liveValidation/payloads/oneOfMissing_input.json
+++ b/test/liveValidation/payloads/oneOfMissing_input.json
@@ -28,7 +28,7 @@
               "audience": "aaaaaaaaaaaaaaaaaaaaaa",
               "primaryVerificationKey": {
                 "@odata.type": "#Microsoft.Media.ContentKeyPolicySymmetricTokenKey",
-                "keyValue": "aaaaaaaaaaaaaaaaaaaaaaaa"
+                "keyValue": "not valid base64"
               },
               "requiredClaims": [
                 {
@@ -64,7 +64,7 @@
       "id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
       "type": "Microsoft.Media/mediaservices/contentKeyPolicies",
       "properties": {
-        "policyId": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "policyId": "not valid base64",
         "created": "2019-03-29T21:20:55.38Z",
         "lastModified": "2019-03-29T21:20:55.38Z",
         "options": [
@@ -79,7 +79,7 @@
               "issuer": "aaaaaaaaaaaaaaaaaaaa",
               "primaryVerificationKey": {
                 "@odata.type": "#Microsoft.Media.ContentKeyPolicySymmetricTokenKey",
-                "keyValue": "aaaaaaaaaaaaaaaaaaaaaaaa"
+                "keyValue": "not valid base64"
               },
               "alternateVerificationKeys": [],
               "requiredClaims": [

--- a/test/modelValidation/swaggers/specification/formatValidation/examples/byte.json
+++ b/test/modelValidation/swaggers/specification/formatValidation/examples/byte.json
@@ -5,7 +5,9 @@
   "responses": {
     "200": {
       "body": {
-        "NotByteValue": "credentialValue1",
+        "NotByteValue": "space is not a valid base64 character",
+        "NotUriSafeValue": "----",
+        "NotPaddedValue": "Y3JlZGVudGlhbFZhbHVlMQ",
         "ByteValue": "Y3JlZGVudGlhbFZhbHVlMQ=="
       }
     }

--- a/test/modelValidation/swaggers/specification/formatValidation/format.json
+++ b/test/modelValidation/swaggers/specification/formatValidation/format.json
@@ -59,7 +59,17 @@
         "NotByteValue": {
           "type": "string",
           "format": "byte",
-          "description": "Base64-encoded data."
+          "description": "Invalid base64-encoded data."
+        },
+        "NotUriSafeValue": {
+          "type": "string",
+          "format": "byte",
+          "description": "Base64-encoded data using non URI-safe characters."
+        },
+        "NotPaddedValue": {
+          "type": "string",
+          "format": "byte",
+          "description": "Base64-encoded data without sufficient padding."
         },
         "ByteValue": {
           "type": "string",

--- a/test/modelValidatorTests.ts
+++ b/test/modelValidatorTests.ts
@@ -855,11 +855,22 @@ describe("Model Validation", () => {
     it("should fail when value is not in base64 format", async () => {
       const specPath2 = `${testPath}/modelValidation/swaggers/specification/formatValidation/format.json`;
       const result = await validate.validateExamples(specPath2, "Byte");
-      assert.strictEqual(result.length, 1);
+      console.log(result)
+      assert.strictEqual(result.length, 3);
       assert.strictEqual(result[0].code, "INVALID_FORMAT");
       assert.strictEqual(
         result[0].message,
-        "Object didn't pass validation for format byte: credentialValue1"
+        "Object didn't pass validation for format byte: space is not a valid base64 character"
+      );
+      assert.strictEqual(result[1].code, "INVALID_FORMAT");
+      assert.strictEqual(
+        result[1].message,
+        "Object didn't pass validation for format byte: ----"
+      );
+      assert.strictEqual(result[2].code, "INVALID_FORMAT");
+      assert.strictEqual(
+        result[2].message,
+        "Object didn't pass validation for format byte: Y3JlZGVudGlhbFZhbHVlMQ"
       );
     });
     it("should fail when value is not in arm-id format", async () => {


### PR DESCRIPTION
When `oav` is validating the `byte` format, it reports errors for many valid base64 strings.

I believe this should permit any valid base64, but the conversion to ASCII is dropping/re-encoding bytes that aren't valid ASCII. The result is that any real base64 in an example (which isn't merely a base-64 encoding of ASCII, as the example generator constructs), will produce a validation error.

Ideally this would return a more precise error message ("here's the character I don't think is valid base64"), as relying on the JS Buffer parser means we only accept url-safe, fully padded values. But that's a larger change, so making this standalone fix for now.

Examples of roundtripping with the code before and after, below
```
function roundtrip_a(x) {
  const decodedValue = Buffer.from(x, "base64").toString("ascii");
  const reencodedValue = Buffer.from(decodedValue).toString("base64");
  console.log(`${x} -> ${reencodedValue} ${x === reencodedValue ? "" : "(MISMATCH)"}`)
}

function roundtrip_b(x) {
  const decodedValue = Buffer.from(x, "base64");
  const reencodedValue = Buffer.from(decodedValue).toString("base64");
  console.log(`${x} -> ${reencodedValue} ${x === reencodedValue ? "" : "(MISMATCH)"}`)
}


> roundtrip_a('aaY=')
aaY= -> aSY= (MISMATCH)

> roundtrip_b('aaY=')
aaY= -> aaY=

> roundtrip_a('1234')
1234 -> V214 (MISMATCH)

> roundtrip_b('1234')
1234 -> 1234

> roundtrip_a('cQ6T')
cQ6T -> cQ4T (MISMATCH)

> roundtrip_b('cQ6T')
cQ6T -> cQ6T

> roundtrip_a('----')
---- -> e28+ (MISMATCH)

> roundtrip_b('----')
---- -> ++++ (MISMATCH)
```