### PR TITLE
Cut `oav` release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log - oav
 
+## 06/14/2023 3.2.10
+
+- Patch `byte` type validation to properly decode and re-encode a base64 string. A `byte` formatted body's validity has **nothing** to do with whether or not one can successfully encode it to ascii.
+
 ## 06/05/2023 3.2.9
 
 - Reverting 3.2.9-beta.1 override changes.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # Change Log - oav
 
-## 06/14/2023 3.2.10
+## 06/15/2023 3.2.10
 
 - Patch `byte` type validation to properly decode and re-encode a base64 string. A `byte` formatted body's validity has **nothing** to do with whether or not one can successfully encode it to ascii.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
We have an actual bugfix! Ensure that we bump the version to account for it.

Includes changes from:

- #979
- #980 
- #981 