### PR TITLE
Re-Enable AdditionalProperties enforcement

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log - oav
 
+## 07/05/2023 3.2.11
+
+- Re-enable `additionalProperties` validation where the `liveValidator` configuration has `isArmCall` set to `false`. The version of `oav` that is being used to validate `azure-rest-api-specs` has this behavior enabled, so this is not a breaking change.
+
 ## 06/15/2023 3.2.10
 
 - Patch `byte` type validation to properly decode and re-encode a base64 string. A `byte` formatted body's validity has **nothing** to do with whether or not one can successfully encode it to ascii.

--- a/lib/liveValidation/liveValidator.ts
+++ b/lib/liveValidation/liveValidator.ts
@@ -58,6 +58,7 @@ export interface LiveValidatorOptions extends LiveValidatorLoaderOption {
   loadValidatorInBackground: boolean;
   loadValidatorInInitialize: boolean;
   enableRoundTripValidator?: boolean;
+  isArmCall?: boolean;
 }
 
 export interface RequestResponsePair {

--- a/lib/liveValidation/operationValidator.ts
+++ b/lib/liveValidation/operationValidator.ts
@@ -305,7 +305,14 @@ export const schemaValidateIssueToLiveValidationIssue = (
           skipIssue = true;
           return "";
         }
-      } else if (issue.code === "INVALID_TYPE" && isArmCall === false) {
+      } else if (issue.code === "INVALID_TYPE" && isArmCall === true) {
+        // See Azure/oav#983 for additional information as to why this special case is present.
+        // RPs working with the RPaaS team were having dificulty with additionalProperties validation due to the fact
+        // that when we turned it on, a LOT of real, live requests were being rejected due to invalid additionalProperties settings.
+        //
+        // We need oav to have the capability to skip this if we are invoking an arm call, but when we roll any new versions of OAV
+        // out to azure/azure-rest-api-specs, we need the errors actually pop there! When enough of the RPs have resolved this problem,
+        // we can re-enable loud failures in the validation image.
         if (issue.schemaPath.includes("additionalProperties")) {
           skipIssue = true;
           if (logging) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.2.10",
+  "version": "3.2.11",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/test/liveValidatorTests.ts
+++ b/test/liveValidatorTests.ts
@@ -1063,7 +1063,7 @@ describe("Live Validator", () => {
         git: {
           shouldClone: false,
         },
-        //isArmCall is false by default
+        isArmCall: true
       };
       const liveValidator = new LiveValidator(options);
       await liveValidator.initialize();


### PR DESCRIPTION
- Version of `oav` being used in `Azure-rest-api-specs` = `3.2.2`
- This [PR](https://github.com/Azure/oav/pull/965/files) introduced as version `3.2.6` makes these `additionalProperties` validations a logged warning by default.
- I have two situations, `oav` when used in `azure-rest-api-specs` SHOULD throw on `additionalProperties` validation errors. `oav` when used in the `validate-v2` RPaaS LiveValidation image, should only **log** these as warnings.
- Prior to this PR, `oav` will not throw on these `additionalProperties` errors at all, as `isArmCall` is DEFAULTED to `false`, which effectively means all of these errors become warnings.
- This PR makes `isArmCall` actually matter, as this `log as warning` code-path will now either skip or not based on the value of `isArmCall` in the LiveValidator. We [have set isArmCall](https://devdiv.visualstudio.com/DevDiv/_git/openapi-platform/pullrequest/482367) in the `validate-v2` `LiveValidator` default setup to allow `RPaaS` folks to continue to have `additionalProperties` errors logged as warnings.