### PR TITLE
[JSON Report] Expose new properties in JSON Report

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,10 @@
 # Change Log - oav
 
-## 09-29-2023 3.2.13
+## 10/19/2023 3.2.14
+
+- #1011 Ehancing JSON report by exposing new properties including `coveredSpecFiles`, `unCoveredOperationsList`, `errorLink` and `schemaPathWithPosition`. 
+
+## 09/29/2023 3.2.13
 
 - #1004 fixes an issue with the injected property refWithReadOnly causing additionalProperty error in schema validator.
 

--- a/lib/report/generateReport.ts
+++ b/lib/report/generateReport.ts
@@ -64,6 +64,16 @@ export interface resultForRendering
   index?: number;
 }
 
+export async function loadErrorDefinitions(): Promise<Map<string, ErrorDefinition>> {
+  const errorDefinitionDoc =
+    require("../../../documentation/error-definitions.json") as ErrorDefinitionDoc;
+  const errorsMap: Map<string, ErrorDefinition> = new Map();
+  errorDefinitionDoc.ErrorDefinitions.forEach((def) => {
+    errorsMap.set(def.code, def);
+  });
+  return errorsMap;
+}
+
 // used to pass data to the template rendering engine
 export class CoverageView {
   public package: string;
@@ -137,7 +147,7 @@ export class CoverageView {
   public async prepareDataForRendering() {
     try {
       this.markdown = await this.readMarkdown();
-      const errorDefinitions = await this.loadErrorDefinitions();
+      const errorDefinitions = await loadErrorDefinitions();
       let errorsForRendering: LiveValidationIssueForRendering[];
       this.sortedValidationResults.forEach((element) => {
         const payloadFile = element.payloadFilePath?.substring(
@@ -301,16 +311,6 @@ export class CoverageView {
       console.error(`Failed in read report.md file`);
       return "";
     }
-  }
-
-  private async loadErrorDefinitions(): Promise<Map<string, ErrorDefinition>> {
-    const errorDefinitionDoc =
-      require("../../../documentation/error-definitions.json") as ErrorDefinitionDoc;
-    const errorsMap: Map<string, ErrorDefinition> = new Map();
-    errorDefinitionDoc.ErrorDefinitions.forEach((def) => {
-      errorsMap.set(def.code, def);
-    });
-    return errorsMap;
   }
 
   private sortOperationIds() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.2.13",
+  "version": "3.2.14",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
## Description

[armstrong](https://github.com/ms-henglu/armstrong) hopes to leverage oav to validate API Test Result and generate its own report. However, current JSON report of oav does not contain the following content:

- Validated Swagger Files in a directory
- Uncovered Operations
- error link of the error code
- the schema path and position of the error

## Changes

To add the content into JSON Report.
