### PR TITLE
Re-enable arm-id validation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log - oav
 
+## 03/27/2024 3.3.4
+
+- Re-enable the arm-id validation in all cases, even when `isArmCall` is `false`. The special handling for this error will be done in RPaaS's codebase.
+
 ## 02/12/2024 3.3.3
 
 - #1014 Set armId format validation to always enabled, but allow suppression of errors when `isArmCall` validator argument is set to `false`. Update the special casing on additionalProperties validation. This error was was erroneously skipping validation validation error when isArmCall is set to `true`. This value is _defaulted_ to `true` when used for `Model Validation` and `Semantic Validation`.
@@ -15,11 +19,11 @@
 
 ## 10/19/2023 3.3.0
 
-- #1011 Enhancing JSON report by exposing new properties including `coveredSpecFiles`, `unCoveredOperationsList`, `errorLink` and `schemaPathWithPosition`. 
+- #1011 Enhancing JSON report by exposing new properties including `coveredSpecFiles`, `unCoveredOperationsList`, `errorLink` and `schemaPathWithPosition`.
 
 ## 10/19/2023 3.2.14
 
-- #1010 Fix an issue with details of `Failed Operations` not displayed in Windows-generated HTML report. 
+- #1010 Fix an issue with details of `Failed Operations` not displayed in Windows-generated HTML report.
 
 ## 09/29/2023 3.2.13
 

--- a/lib/liveValidation/operationValidator.ts
+++ b/lib/liveValidation/operationValidator.ts
@@ -329,22 +329,6 @@ export const schemaValidateIssueToLiveValidationIssue = (
           }
           return "";
         }
-      } else if (
-        issue.code === "INVALID_FORMAT" &&
-        isArmCall === false &&
-        issue.message.includes("Object didn't pass validation for format arm-id")
-      ) {
-        skipIssue = true;
-        if (logging) {
-          logging(
-            `armId format validation failed: ${JSON.stringify(issue, undefined, 2)}`,
-            LiveValidatorLoggingLevels.error,
-            LiveValidatorLoggingTypes.trace,
-            "Oav.OperationValidator.schemaValidateIssueToLiveValidationIssue",
-            undefined,
-            operationContext.validationRequest
-          );
-        }
       }
 
       const isMissingRequiredProperty = issue.code === "OBJECT_MISSING_REQUIRED_PROPERTY";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oav",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oav",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "10.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/test/liveValidatorTests.ts
+++ b/test/liveValidatorTests.ts
@@ -1073,7 +1073,7 @@ describe("Live Validator", () => {
       assert.strictEqual(result.requestValidationResult.isSuccessful, true);
     });
 
-    it(`should only log error invalid format on arm-id if isArmCall is set to false`, async () => {
+    it(`should throw error invalid format on arm-id even if isArmCall is set to false`, async () => {
       const options = {
         directory: `${__dirname}/modelValidation/swaggers/`,
         isPathCaseSensitive: false,
@@ -1090,7 +1090,7 @@ describe("Live Validator", () => {
       await liveValidator.initialize();
       const payload = require(`${__dirname}/liveValidation/payloads/invalid_armid_format.json`);
       const result = await liveValidator.validateLiveRequestResponse(payload);
-      assert.strictEqual(result.responseValidationResult.errors.some((err) => err.code === "INVALID_FORMAT"), false)
+      assert.strictEqual(result.responseValidationResult.errors.some((err) => err.code === "INVALID_FORMAT"), true)
     });
   });
 });


### PR DESCRIPTION
Re-enables the arm-id validation in all cases, even when `isArmCall` is `false`. The special handling for this error will be done in RPaaS's codebase.