### PR TITLE
Support all current LTS Node versions (>=18.0.0)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log - oav
 
+## 05/31/2024 3.3.6
+
+- Support all current LTS Node versions (>=18.0.0)
+
 ## 05/7/2024 3.3.5
 
 - Bump Node engine version requirement for security vulnerability.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oav",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "oav",
-      "version": "3.3.5",
+      "version": "3.3.6",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "10.0.3",
@@ -88,7 +88,7 @@
         "typescript": "^3.9.10"
       },
       "engines": {
-        "node": ">=20.11.1"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.3.5",
+  "version": "3.3.6",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",
@@ -131,7 +131,7 @@
     "li": "npm install @ts-common/local-install --no-save && local-install"
   },
   "engines": {
-    "node": ">=20.11.1"
+    "node": ">=18.0.0"
   },
   "jest-junit": {
     "output": "test-results.xml"


### PR DESCRIPTION
- Overrides #1029

We should support all current LTS Node versions (>=18.0.0) for maximum compatibility.  Matches other packages like `@typespec/compiler`:

https://github.com/microsoft/typespec/blob/98f8d62e3fa8a01f9a594853b27985d071a03355/packages/compiler/package.json#L50

Detected failure when trying to add `oav` to `azure-rest-api-specs/package.json`:

https://github.com/Azure/azure-rest-api-specs/actions/runs/9327612995/job/25677733715#step:4:13