### PR TITLE
Don't generate examples for `password` with a random string

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log - oav
 
+## 07/12/2024 3.4.0
+
+- During example generation, fields `password`, `adminPassword`, and `pwd` are all generated with a single value of "<a-password-goes-here>" instead of random characters.
+
 ## 06/17/2024 3.3.8
 
 - Remove suppression of `additionalProperties` errors when `isArmCall === true`. (ARM liveValidation scenarios)

--- a/lib/generator/mocker.ts
+++ b/lib/generator/mocker.ts
@@ -34,7 +34,7 @@ export default class Mocker {
     }
 
     if (paramName === "password" || paramName === "pwd" || paramName === "adminPassword") {
-      return "SecretPlaceHolder";
+      return "<a-password-goes-here>";
     }
 
     if (paramSpec.format === "date") {

--- a/lib/generator/mocker.ts
+++ b/lib/generator/mocker.ts
@@ -29,11 +29,13 @@ export default class Mocker {
   }
 
   private generateString(paramSpec: any, paramName: string) {
+    const pwdParams = ["password", "pwd", "adminPassword"];
+
     if (paramSpec.name === "subscriptionId") {
       return uuid.v4().toUpperCase();
     }
 
-    if (paramName === "password" || paramName === "pwd" || paramName === "adminPassword") {
+    if (pwdParams.includes(paramName)) {
       return "<a-password-goes-here>";
     }
 

--- a/lib/generator/mocker.ts
+++ b/lib/generator/mocker.ts
@@ -33,6 +33,10 @@ export default class Mocker {
       return uuid.v4().toUpperCase();
     }
 
+    if (paramName === "password" || paramName === "pwd" || paramName === "adminPassword") {
+      return "SecretPlaceHolder";
+    }
+
     if (paramSpec.format === "date") {
       return new Date().toISOString().split("T")[0];
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oav",
-  "version": "3.3.7",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oav",
-      "version": "3.3.7",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "10.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.3.8",
+  "version": "3.4.0",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/test/liveValidatorTests.ts
+++ b/test/liveValidatorTests.ts
@@ -1071,7 +1071,7 @@ describe("Live Validator", () => {
       const result = await liveValidator.validateLiveRequestResponse(payload);
 
       assert.strictEqual(result.responseValidationResult.errors.length, 1);
-      assert.strictEqual(result.responseValidationResult.errors[0].code, "INVALID_TYPE")
+      assert.strictEqual(result.responseValidationResult.errors[0].code, "INVALID_TYPE");
       assert.strictEqual(result.responseValidationResult.isSuccessful, false);
       assert.strictEqual(result.requestValidationResult.isSuccessful, true);
     });


### PR DESCRIPTION
Resolves #1041 

Instead we are generating with the value `<a-password-goes-here>`.

This makes it obvious to users of the example, without breaking any workflows. I'll take care of adding this value to credscan necessary.

"SecretPlaceHolder" seemed almost arbitrary to me, and I figured I'd encode a bit more data in the value. If we just want to use that original string then I'll just do that.