### PR TITLE
Add Passed opeartions to the report

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log - oav
 
+## 09/12/2024 3.5.0
+
+- Add names of `Passed Operations` in the HTML and JSON reports. 
+
 ## 07/12/2024 3.4.0
 
 - During example generation, fields `password`, `adminPassword`, and `pwd` are all generated with a single value of "<a-password-goes-here>" instead of random characters.

--- a/lib/apiScenario/coverageCalculator.ts
+++ b/lib/apiScenario/coverageCalculator.ts
@@ -10,6 +10,7 @@ export interface OperationCoverageResult {
   coveredOperationNumber: number;
   totalOperationNumber: number;
   coverage: number;
+  coveredOperationIds: string[];
   uncoveredOperationIds: string[];
 }
 
@@ -22,6 +23,7 @@ export class CoverageCalculator {
       coveredOperationNumber: 0,
       totalOperationNumber: 0,
       coverage: 0,
+      coveredOperationIds: [],
       uncoveredOperationIds: [],
     };
 
@@ -55,6 +57,7 @@ export class CoverageCalculator {
       allOperationIds.size === 0 ? 0 : coverageOperationIds.size / allOperationIds.size;
     ret.coveredOperationNumber = coverageOperationIds.size;
     ret.totalOperationNumber = allOperationIds.size;
+    ret.coveredOperationIds = [...coverageOperationIds];
     const difference = [...allOperationIds].filter((x) => !coverageOperationIds.has(x));
     ret.uncoveredOperationIds = difference;
     return ret;
@@ -70,6 +73,7 @@ export class CoverageCalculator {
         coveredOperationNumber: 0,
         totalOperationNumber: 0,
         coverage: 0,
+        coveredOperationIds: [],
         uncoveredOperationIds: [],
       };
 
@@ -102,6 +106,7 @@ export class CoverageCalculator {
         allOperationIds.size === 0 ? 0 : coverageOperationIds.size / allOperationIds.size;
       result.coveredOperationNumber = coverageOperationIds.size;
       result.totalOperationNumber = allOperationIds.size;
+      result.coveredOperationIds = [...coverageOperationIds];
       const difference = [...allOperationIds].filter((x) => !coverageOperationIds.has(x));
       result.uncoveredOperationIds = difference;
 

--- a/lib/apiScenario/postmanCollectionGenerator.ts
+++ b/lib/apiScenario/postmanCollectionGenerator.ts
@@ -376,6 +376,9 @@ class PostmanCollectionRunner {
         apiVersion: getApiVersionFromFilePath(specPath),
         unCoveredOperations: result.uncoveredOperationIds.length,
         coveredOperations: result.totalOperationNumber - result.uncoveredOperationIds.length,
+        coveredOperationsList: result.coveredOperationIds.map((id) => {
+          return { operationId: id };
+        }),
         validationFailOperations: new Set(
           trafficValidationResult
             .filter((it) => key.indexOf(it.specFilePath!) !== -1 && it.errors!.length > 0)

--- a/lib/templates/baseLayout.mustache
+++ b/lib/templates/baseLayout.mustache
@@ -280,7 +280,52 @@
             white-space: nowrap;
         }
 
+        .testPassed {
+            margin-bottom: 40px;
+        }
+        
+        .testPassed table {
+            border: none;
+        }
+
+        .testPassed .table-body {
+            border: none;
+        }
+
+        .testPassed .table-body>table>tbody>tr>td {
+            border: none;
+        }
+
+        .testPassed .table-body table tbody tr td {
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        .testPassed table tbody tr td:nth-child(-n + 2) {
+            text-align: center;
+            word-break: break-all;
+        }
+
+        .testPassed .operationTag {
+            text-align: left;
+        }
+
+        .testPassed .operationTag .tag {
+            color: var(--report-base-colo);
+            background-color: var(--report-bg-blue);
+            border: 1px solid var(--report-bg-blue);
+            display: inline-block;
+            height: 32px;
+            padding: 0 10px;
+            margin: 4px 2px;
+            line-height: 30px;
+            font-size: 14px;
+            border-radius: 4px;
+            box-sizing: border-box;
+            white-space: nowrap;
+        }
+
         .notTested table,
+        .testPassed table,
         .testFailed table,
         .runtimeExceptions table,
         .innerTable table {
@@ -556,7 +601,11 @@
                                    </span>
                                 ( {{validationFailOperations}} )
                                 </th>
-                                <th style="background-color: var(--report-bg-green);">Pass ( {{validationPassOperations}} )</th>
+                                <th style="background-color: var(--report-bg-green);">
+                                    Pass<span class="hashLinkClass" data-hash-link="testPassed_{{index}}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 2048" class="svg_dd790ee3 x-hidden-focus" focusable="false" width="25" height="15" style="vertical-align: middle;"><path d="M1707 715q76 27 139 75t108 111 69 138 25 156q0 106-40 199t-110 162-163 110-199 41h-512q-106 0-199-40t-162-110-110-163-41-199q0-106 40-199t110-162 163-110 199-41h171q0 35-13 66t-37 54-55 36-66 14q-71 0-133 27t-108 73-73 109-27 133q0 71 27 133t73 108 108 73 133 27h512q70 0 132-27t109-73 73-108 27-133q0-92-46-168t-124-123V715zM171 683q0 91 46 167t124 124v189q-76-27-139-75T94 977 25 839 0 683q0-106 40-199t110-162 163-110 199-41h512q106 0 199 40t162 110 110 163 41 199q0 106-40 199t-110 162-163 110-199 41H853q0-35 13-66t37-54 54-37 67-14q70 0 132-27t109-73 73-108 27-133q0-70-26-132t-73-109-109-74-133-27H512q-71 0-133 27t-108 73-73 109-27 133z" class="x-hidden-focus"></path></svg> 
+                                    ( {{validationPassOperations}} )
+                                    </span>
+                                </th>
                                 <th style="background-color: var(--report-bg-blue);">
                                     <div class="file">
                                         {{specLinkLabel}}<a target="_blank" href="{{spec}}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 2048" class="svg_dd790ee3 x-hidden-focus" focusable="false" width="25" height="15" style="vertical-align: middle;"><path d="M1707 715q76 27 139 75t108 111 69 138 25 156q0 106-40 199t-110 162-163 110-199 41h-512q-106 0-199-40t-162-110-110-163-41-199q0-106 40-199t110-162 163-110 199-41h171q0 35-13 66t-37 54-55 36-66 14q-71 0-133 27t-108 73-73 109-27 133q0 71 27 133t73 108 108 73 133 27h512q70 0 132-27t109-73 73-108 27-133q0-92-46-168t-124-123V715zM171 683q0 91 46 167t124 124v189q-76-27-139-75T94 977 25 839 0 683q0-106 40-199t110-162 163-110 199-41h512q106 0 199 40t162 110 110 163 41 199q0 106-40 199t-110 162-163 110-199 41H853q0-35 13-66t37-54 54-37 67-14q70 0 132-27t109-73 73-108 27-133q0-70-26-132t-73-109-109-74-133-27H512q-71 0-133 27t-108 73-73 109-27 133z" class="x-hidden-focus"></path></svg></a>
@@ -661,6 +710,33 @@
                                 </td>
                             </tr>
                             {{/unCoveredOperationsListGen}}
+                        </tbody>
+                    </table>
+                </div>
+            </article>
+        </section>
+
+        <section class="testPassed">
+            <h2 class="title" id="testPassed_{{index}}">Passed Operations ( {{validationPassOperations}} )</h2>
+            <article>
+                <div class="table-body">
+                    <table summary="Operations Test Passed" cellspacing="0" cellpadding="0">
+                        <colgroup>
+                            <col style="width: 15%" />
+                            <col style="width: 85%" />
+                        </colgroup>
+                        <tbody>
+                            {{#validationPassOperationList}}
+                            <tr>
+                                <td colspan="2">
+                                    <div class="operationTag">
+                                        {{#operationIdList}}
+                                        <span class="tag">{{operationId}}<a target="_blank" href="{{spec}}"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2048 2048" class="svg_dd790ee3 x-hidden-focus" focusable="false" width="25" height="15" style="vertical-align: middle;"><path d="M1707 715q76 27 139 75t108 111 69 138 25 156q0 106-40 199t-110 162-163 110-199 41h-512q-106 0-199-40t-162-110-110-163-41-199q0-106 40-199t110-162 163-110 199-41h171q0 35-13 66t-37 54-55 36-66 14q-71 0-133 27t-108 73-73 109-27 133q0 71 27 133t73 108 108 73 133 27h512q70 0 132-27t109-73 73-108 27-133q0-92-46-168t-124-123V715zM171 683q0 91 46 167t124 124v189q-76-27-139-75T94 977 25 839 0 683q0-106 40-199t110-162 163-110 199-41h512q106 0 199 40t162 110 110 163 41 199q0 106-40 199t-110 162-163 110-199 41H853q0-35 13-66t37-54 54-37 67-14q70 0 132-27t109-73 73-108 27-133q0-70-26-132t-73-109-109-74-133-27H512q-71 0-133 27t-108 73-73 109-27 133z" class="x-hidden-focus"></path></svg></a></span>
+                                        {{/operationIdList}}
+                                    </div>
+                                </td>
+                            </tr>
+                            {{/validationPassOperationList}}
                         </tbody>
                     </table>
                 </div>

--- a/lib/validate.ts
+++ b/lib/validate.ts
@@ -235,6 +235,18 @@ export async function validateTraffic(
             operationIds: item.unCoveredOperationsList.map((opeartion) => opeartion.operationId),
           };
         }),
+        passedOperationsList: validator.operationCoverageResult.map((item) => {
+          return {
+            spec: item.spec,
+            operationIds: item.coveredOperationsList
+              .map((opeartion) => opeartion.operationId)
+              .filter((id) => {
+                return !trafficValidationResult.some(
+                  (error) => error.operationInfo?.operationId === id
+                );
+              }),
+          };
+        }),
         failedOperations: validator.operationCoverageResult
           .map((item) => item.validationFailOperations)
           .reduce((a, b) => a + b, 0),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oav",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oav",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "10.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",

--- a/test/__snapshots__/trafficValidatorTests.ts.snap
+++ b/test/__snapshots__/trafficValidatorTests.ts.snap
@@ -7,6 +7,14 @@ Object {
       "apiVersion": "2019-02-02",
       "coverageRate": 0.14285714285714285,
       "coveredOperations": 2,
+      "coveredOperationsList": Array [
+        Object {
+          "operationId": "Table_Delete",
+        },
+        Object {
+          "operationId": "Table_Query",
+        },
+      ],
       "totalOperations": 14,
       "unCoveredOperations": 12,
       "unCoveredOperationsList": Array [


### PR DESCRIPTION
Some users complained that they do not know which operations are tested successfully from the report. This PR adds the passed operations to the report.

![image](https://github.com/user-attachments/assets/7c837300-4746-45ef-9654-a3521a2a8442)
