### PR TITLE
[generate-examples] Include Min/Max in default example titles

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log - oav
 
+## 10/15/2024 3.5.1
+
+- Include min/max in example titles
+
 ## 09/12/2024 3.5.0
 
 - Add names of `Passed Operations` in the HTML and JSON reports.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 10/15/2024 3.5.1
 
-- Include min/max in example titles
+- During example generation, include min/max in default titles.
 
 ## 09/12/2024 3.5.0
 

--- a/lib/generator/exampleGenerator.ts
+++ b/lib/generator/exampleGenerator.ts
@@ -170,7 +170,7 @@ export default class Generator {
     let example;
     console.log(`start generated example for ${operationId}, rule:${rule.ruleName}`);
     if (!this.shouldMock) {
-      example = this.getExampleFromPayload(operationId, specItem);
+      example = this.getExampleFromPayload(operationId, specItem, rule);
       if (!example) {
         return [];
       }
@@ -186,7 +186,7 @@ export default class Generator {
             ? specItem.content.summary
             : specItem.content.description
             ? specItem.content.description
-            : operationId,
+            : `${operationId}_${rule.exampleNamePostfix}`,
         operationId: operationId,
         parameters: {},
         responses: this.extractResponse(specItem, {}),
@@ -366,7 +366,7 @@ export default class Generator {
     return example;
   }
 
-  private getExampleFromPayload(operationId: string, specItem: any) {
+  private getExampleFromPayload(operationId: string, specItem: any, rule: ExampleRule) {
     if (this.payloadDir) {
       const subPaths = path.dirname(this.specFilePath).split(/\\|\//).slice(-3).join("/");
       const payloadDir = path.join(this.payloadDir, subPaths);
@@ -387,7 +387,7 @@ export default class Generator {
           ? specItem.content.summary
           : specItem.content.description
           ? specItem.content.description
-          : operationId,
+          : `${operationId}_${rule.exampleNamePostfix}`,
         operationId: operationId,
         parameters: this.extractRequest(specItem, payload),
         responses: this.extractResponse(specItem, payload),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
- Fixes #935 
- Uses unique titles when first generating examples
- Still has unrelated bugs where title can be changed when updating existing examples
