### PR TITLE
Fix `oav` to account for `path-to-regexp` sanitization requirements

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Change Log - oav
 
+## 06/16/2025 3.6.1
+
+- Fix #1069 by properly escaping bare `:`s during processing of paths in specs.
+  - In `path-to-regex`, [parameters](https://github.com/pillarjs/path-to-regexp?tab=readme-ov-file#parameters) are a concept used to match arbitrary strings of a specific part of a path being converted to regex. These are referred to by the format `:<name or index>:`. By upgrading to 6.2.1, path elements that contain a `:` are now treated as an unmatched parameter indicator. This is the origin of the error `Must have text between two parameters` that is being surfaced for paths that have `:` within them. This patch ensures that these input `:` are properly escaped, resulting in `path-to-regexp` not crashing on strings that look like `"/test-runs/{testRunId}:stop"`.
+
 ## 10/23/2024 3.6.0
 
 - Update `LiveValidationIssue` to include `resourceIds`, an array of the located resourceIds associated with the erroneous jsonPaths.

--- a/lib/transform/pathRegexTransformer.ts
+++ b/lib/transform/pathRegexTransformer.ts
@@ -12,6 +12,16 @@ export type RegExpWithKeys = RegExp & {
   _hostTemplate?: boolean;
   _hasMultiPathParam?: boolean;
 };
+
+/**
+ * Escapes literal colons in a path string for path-to-regexp v6 compatibility.
+ * Only colons not followed by a valid parameter name are escaped.
+ */
+function escapeLiteralColons(path: string): string {
+  // Escape all colons not followed by a digit (which are parameter indices)
+  return path.replace(/:(?![0-9])/g, "\\:");
+}
+
 const buildPathRegex = (
   hostTemplate: string,
   basePathPrefix: string,
@@ -74,7 +84,11 @@ const buildPathRegex = (
   const processedPath = hostTemplate + basePathPrefix + path;
 
   const keys: Key[] = [];
-  const regexp = pathToRegexp(processedPath, keys, { sensitive: false });
+
+  // in security patched versions of path-to-regexp (read > 6.2.1), colons must refer to valid parameter names
+  // so now we have to escape literal colons that are in the path
+  const escapedPath = escapeLiteralColons(processedPath);
+  const regexp = pathToRegexp(escapedPath, keys, { sensitive: false });
 
   // restore parameter name
   const _keys: string[] = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oav",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oav",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "10.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "json-merge-patch": "^1.0.2",
         "json-pointer": "^0.6.2",
         "json-schema-traverse": "^0.4.1",
-        "jsonpath-plus": "^10.2.0",
+        "jsonpath-plus": "^10.3.0",
         "junit-report-builder": "^3.0.0",
         "lodash": "^4.17.21",
         "md5-file": "^5.0.0",
@@ -7019,9 +7019,10 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.2.0.tgz",
-      "integrity": "sha512-T9V+8iNYKFL2n2rF+w02LBOT2JjDnTjioaNFrxRy0Bv1y/hNsqR/EBK7Ojy2ythRHwmz2cRIls+9JitQGZC/sw==",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "license": "MIT",
       "dependencies": {
         "@jsep-plugin/assignment": "^1.3.0",
         "@jsep-plugin/regex": "^1.0.4",
@@ -8222,9 +8223,10 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "json-merge-patch": "^1.0.2",
     "json-pointer": "^0.6.2",
     "json-schema-traverse": "^0.4.1",
-    "jsonpath-plus": "^10.2.0",
+    "jsonpath-plus": "^10.3.0",
     "junit-report-builder": "^3.0.0",
     "lodash": "^4.17.21",
     "md5-file": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
Resolves #1069 

@mikeharder you made me noodle a bit based on

> Has this ALWAYS been failing?

I did a fresh `npm install` from the `oav` repo, and the issue _didn't_ repro. That made me immediately start side-eying the dependencies to understand what went wrong. This PR fixes the issue with bare `:` being treated as improperly formatted parameters -- a fix that came in later versions of `path-to-regexp`.