### PR TITLE
Support identifier chars after params in path-to-regexp@6.3.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # Change Log - oav
 
+## 07/17/2025 3.6.3
+
+- Follow up on 3.6.1 dealing with edge-cases broken by security fixes in `path-to-regexp@6.3.0`. `oav` now properly handles identifier characters immediately following a parameter - EG `{param1}x{param2}`.
+
 ## 6/19/2025 3.6.2
 
 - Set override for `braces@3.0.3` and update package lock to reflect

--- a/lib/transform/pathRegexTransformer.ts
+++ b/lib/transform/pathRegexTransformer.ts
@@ -37,7 +37,7 @@ function replaceParam(path: string, name: string, index: number) {
     // This only applies to a small number of paths with segments like "{width}x{height}".
     // Without this fix, the paths would fail with: "TypeError: Must have text between two parameters".
     //
-    // If a param has a custom regex (eg "{foo}([^a]+)"), nextChar will be "(", so this is a no-op.
+    // If a param has a custom regex (e.g. "{foo}([^a]+)"), nextChar will be "(", so this is a no-op.
     if (/^\w$/.test(nextChar)) {
       // Chars excluded by default, if a param has no custom regex
       const defaultExclusions = "\\/#\\?";

--- a/lib/transform/pathRegexTransformer.ts
+++ b/lib/transform/pathRegexTransformer.ts
@@ -48,9 +48,7 @@ function replaceParam(path: string, name: string, index: number) {
     }
   }
 
-  path = path.replace(paramWithBraces, ":" + index);
-  console.log(`path: ${path}`);
-  return path;
+  return path.replace(paramWithBraces, ":" + index);
 }
 
 const buildPathRegex = (

--- a/lib/transform/pathRegexTransformer.ts
+++ b/lib/transform/pathRegexTransformer.ts
@@ -1,8 +1,8 @@
-import { parse as urlParse } from "url";
 import { Key, pathToRegexp } from "path-to-regexp";
+import { parse as urlParse } from "url";
+import { OperationMatch } from "../liveValidation/operationSearcher";
 import { lowerHttpMethods, Parameter, PathParameter, Schema } from "../swagger/swaggerTypes";
 import { xmsParameterizedHost } from "../util/constants";
-import { OperationMatch } from "../liveValidation/operationSearcher";
 import { resolveNestedDefinitionTransformer } from "./resolveNestedDefinitionTransformer";
 import { SpecTransformer, TransformerType } from "./transformer";
 import { traverseSwagger } from "./traverseSwagger";
@@ -26,7 +26,7 @@ function replaceParam(path: string, name: string, index: number) {
   const paramWithBraces = "{" + name + "}";
 
   const start = path.indexOf(paramWithBraces);
-  const end = start + paramWithBraces.length;
+  const end = start + paramWithBraces.length - 1;
   const next = end + 1;
   if (next < path.length) {
     const nextChar = path[next];
@@ -48,7 +48,9 @@ function replaceParam(path: string, name: string, index: number) {
     }
   }
 
-  return path.replace(paramWithBraces, ":" + index);
+  path = path.replace(paramWithBraces, ":" + index);
+  console.log(`path: ${path}`);
+  return path;
 }
 
 const buildPathRegex = (

--- a/lib/transform/pathRegexTransformer.ts
+++ b/lib/transform/pathRegexTransformer.ts
@@ -1,8 +1,8 @@
-import { Key, pathToRegexp } from "path-to-regexp";
 import { parse as urlParse } from "url";
-import { OperationMatch } from "../liveValidation/operationSearcher";
+import { Key, pathToRegexp } from "path-to-regexp";
 import { lowerHttpMethods, Parameter, PathParameter, Schema } from "../swagger/swaggerTypes";
 import { xmsParameterizedHost } from "../util/constants";
+import { OperationMatch } from "../liveValidation/operationSearcher";
 import { resolveNestedDefinitionTransformer } from "./resolveNestedDefinitionTransformer";
 import { SpecTransformer, TransformerType } from "./transformer";
 import { traverseSwagger } from "./traverseSwagger";

--- a/lib/transform/pathRegexTransformer.ts
+++ b/lib/transform/pathRegexTransformer.ts
@@ -22,6 +22,10 @@ function escapeLiteralColons(path: string): string {
   return path.replace(/:(?![0-9])/g, "\\:");
 }
 
+function replaceParam(path: string, name: string, index: number) {
+  return path.replace("{" + name + "}", ":" + index);
+}
+
 const buildPathRegex = (
   hostTemplate: string,
   basePathPrefix: string,
@@ -76,8 +80,8 @@ const buildPathRegex = (
       path = path.replace("{" + v + "}", "(.*)");
       hasMultiPathParam = true;
     } else {
-      hostTemplate = hostTemplate.replace("{" + v + "}", ":" + i);
-      path = path.replace("{" + v + "}", ":" + i);
+      hostTemplate = replaceParam(hostTemplate, v, i);
+      path = replaceParam(path, v, i);
     }
   });
 

--- a/lib/transform/pathRegexTransformer.ts
+++ b/lib/transform/pathRegexTransformer.ts
@@ -35,8 +35,7 @@ function replaceParam(path: string, name: string, index: number) {
     // to a custom regex for the param.
     //
     // This only applies to a small number of paths with segments like "{width}x{height}".
-    // Without this fix, the paths would fail with error:
-    // "TypeError: Must have text between two parameters".
+    // Without this fix, the paths would fail with: "TypeError: Must have text between two parameters".
     //
     // If a param has a custom regex (eg "{foo}([^a]+)"), nextChar will be "(", so this is a no-op.
     if (/^\w$/.test(nextChar)) {

--- a/lib/transform/pathRegexTransformer.ts
+++ b/lib/transform/pathRegexTransformer.ts
@@ -1,8 +1,8 @@
-import { parse as urlParse } from "url";
 import { Key, pathToRegexp } from "path-to-regexp";
+import { parse as urlParse } from "url";
+import { OperationMatch } from "../liveValidation/operationSearcher";
 import { lowerHttpMethods, Parameter, PathParameter, Schema } from "../swagger/swaggerTypes";
 import { xmsParameterizedHost } from "../util/constants";
-import { OperationMatch } from "../liveValidation/operationSearcher";
 import { resolveNestedDefinitionTransformer } from "./resolveNestedDefinitionTransformer";
 import { SpecTransformer, TransformerType } from "./transformer";
 import { traverseSwagger } from "./traverseSwagger";
@@ -23,7 +23,33 @@ function escapeLiteralColons(path: string): string {
 }
 
 function replaceParam(path: string, name: string, index: number) {
-  return path.replace("{" + name + "}", ":" + index);
+  const paramWithBraces = "{" + name + "}";
+
+  const start = path.indexOf(paramWithBraces);
+  const end = start + paramWithBraces.length;
+  const next = end + 1;
+  if (next < path.length) {
+    const nextChar = path[next];
+
+    // In path-to-regexp@6.3.0, if the char following a param is a word char, it must be added
+    // to a custom regex for the param.
+    //
+    // This only applies to a small number of paths with segments like "{width}x{height}".
+    // Without this fix, the paths would fail with error:
+    // "TypeError: Must have text between two parameters".
+    //
+    // If a param has a custom regex (eg "{foo}([^a]+)"), nextChar will be "(", so this is a no-op.
+    if (/^\w$/.test(nextChar)) {
+      // Chars excluded by default, if a param has no custom regex
+      const defaultExclusions = "\\/#\\?";
+      path = path.replace(
+        paramWithBraces,
+        paramWithBraces + `([^${defaultExclusions}${nextChar}]+)`
+      );
+    }
+  }
+
+  return path.replace(paramWithBraces, ":" + index);
 }
 
 const buildPathRegex = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oav",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oav",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "10.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oav",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "author": {
     "name": "Microsoft Corporation",
     "email": "azsdkteam@microsoft.com",


### PR DESCRIPTION
- fixes #1073