### PR TITLE
Remove unused dependency `moment`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,8 @@
 
 - Bump dependency `uuid` from `^3.4.0` to `^8.3.2`
 - Bump dependency `yargs` from `^15.4.1` to `^18.0.0`
-- Remove unused dependency `moment`
+- Remove unused dependencies
+  - moment
 
 ## 08/19/2025 4.0.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 - Bump dependency `uuid` from `^3.4.0` to `^8.3.2`
 - Bump dependency `yargs` from `^15.4.1` to `^18.0.0`
+- Remove unused dependency `moment`
 
 ## 08/19/2025 4.0.0
 
@@ -118,18 +119,20 @@
     - `qs@6.5.3 -> 6.8.3`
 
 # 04/12/2023 3.2.8
+
 - Dependency updates
   - "@azure/core-http `^2.2.7` -> `^3.0.1`
   - Upgrading core-http allows us to bump the dependency on `xmljs2` to one without a CVE
 
 ## 02/24/2023 3.2.7
+
 - Fix roundtrip validation model with circular reference
 
 ## 02/23/2023 3.2.6
 
 - Improved the API scenario long running operation pooling mechanism.
-    - support for checking final-via-state
-    - update the mechanism of gettig the lro polling url.
+  - support for checking final-via-state
+  - update the mechanism of gettig the lro polling url.
 - Support generating the ARM rules for api scenario.
 
 ## 02/19/2023 3.2.6

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -119,20 +119,18 @@
     - `qs@6.5.3 -> 6.8.3`
 
 # 04/12/2023 3.2.8
-
 - Dependency updates
   - "@azure/core-http `^2.2.7` -> `^3.0.1`
   - Upgrading core-http allows us to bump the dependency on `xmljs2` to one without a CVE
 
 ## 02/24/2023 3.2.7
-
 - Fix roundtrip validation model with circular reference
 
 ## 02/23/2023 3.2.6
 
 - Improved the API scenario long running operation pooling mechanism.
-  - support for checking final-via-state
-  - update the mechanism of gettig the lro polling url.
+    - support for checking final-via-state
+    - update the mechanism of gettig the lro polling url.
 - Support generating the ARM rules for api scenario.
 
 ## 02/19/2023 3.2.6

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "lodash": "^4.17.21",
         "md5-file": "^5.0.0",
         "mkdirp": "^1.0.4",
-        "moment": "^2.29.3",
         "mustache": "^4.2.0",
         "path-to-regexp": "^6.2.1",
         "reflect-metadata": "^0.1.13",
@@ -7237,14 +7236,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "lodash": "^4.17.21",
     "md5-file": "^5.0.0",
     "mkdirp": "^1.0.4",
-    "moment": "^2.29.3",
     "mustache": "^4.2.0",
     "path-to-regexp": "^6.2.1",
     "reflect-metadata": "^0.1.13",


### PR DESCRIPTION
- has been a dependency since the tool was first created
- no code uses it, and it's not even a transitive dep, so removing it should have no downside
