### PR TITLE
Bump typescript from 3.9.10 to 4.3.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,5 +31,5 @@ updates:
       # locked to 2.8.8, for compat with our version of TypeScript
       - dependency-name: "prettier"
 
-      # locked to "^3.9.10", for compat with our TS code
+      # locked to "~4.3.5", for compat with our TS code
       - dependency-name: "typescript"

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "2.8.8",
         "ts-jest": "~26.5.6",
-        "typescript": "~4.0.0"
+        "typescript": "~4.1.6"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9849,9 +9849,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
-      "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.6.tgz",
+      "integrity": "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "2.8.8",
         "ts-jest": "~26.5.6",
-        "typescript": "~4.1.6"
+        "typescript": "~4.3.5"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9849,9 +9849,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.6.tgz",
-      "integrity": "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "2.8.8",
         "ts-jest": "~26.5.6",
-        "typescript": "^3.9.10"
+        "typescript": "~4.0.0"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -9849,10 +9849,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.8.tgz",
+      "integrity": "sha512-oz1765PN+imfz1MlZzSZPtC/tqcwsCyIYA8L47EkRnRW97ztRk83SzMiWLrnChC0vqoYxSU1fcFUDA5gV/ZiPg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "2.8.8",
     "ts-jest": "~26.5.6",
-    "typescript": "~4.1.6"
+    "typescript": "~4.3.5"
   },
   "homepage": "https://github.com/azure/oav",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "2.8.8",
     "ts-jest": "~26.5.6",
-    "typescript": "~4.0.8"
+    "typescript": "~4.1.6"
   },
   "homepage": "https://github.com/azure/oav",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "2.8.8",
     "ts-jest": "~26.5.6",
-    "typescript": "^3.9.10"
+    "typescript": "~4.0.8"
   },
   "homepage": "https://github.com/azure/oav",
   "repository": {


### PR DESCRIPTION
- 4.3.5 is the highest version without breaking changes that impact our code