### PR TITLE
bump winston from 3.16.0 to 3.17.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,10 +23,6 @@ updates:
       # locked to "^6.3.0", since newer majors remove features we depend on
       - dependency-name: "path-to-regexp"
 
-      # locked to ~3.16.0, since newer minors include an undocumented breaking change in typings that impacts us
-      # https://github.com/winstonjs/winston/issues/2528
-      - dependency-name: "winston"
-
       # locked to ^15.4.1, since newer majors include breaking changes that may impact us
       - dependency-name: "yargs"
 
@@ -47,9 +43,3 @@ updates:
 
       # locked to "~4.9.5", for compat with our TS code
       - dependency-name: "typescript"
-
-      # overrides
-
-      # locked to ~2.6.1, since newer minors include an undocumented breaking change in typings that impacts us
-      # https://github.com/winstonjs/logform/issues/336
-      - dependency-name: "logform"

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 09/26/2025 4.0.2
 
 - Requires Node 20 or higher
+- Bump dependency `winston` from `~3.16.0` to `^3.17.0`
 
 ## 09/19/2025 4.0.1
 

--- a/lib/apiScenario/logger.ts
+++ b/lib/apiScenario/logger.ts
@@ -8,7 +8,7 @@ export const logger = winston.createLogger({
         winston.format.colorize({
           message: true,
         }),
-        winston.format.printf((info) => info.message)
+        winston.format.printf((info) => String(info.message))
       ),
     }),
   ],

--- a/lib/apiScenario/logger.ts
+++ b/lib/apiScenario/logger.ts
@@ -8,6 +8,8 @@ export const logger = winston.createLogger({
         winston.format.colorize({
           message: true,
         }),
+        // Likely a bug that 'info.message' has type 'unknown', but it's easy to workaround by converting to string
+        // https://github.com/winstonjs/winston/issues/2528
         winston.format.printf((info) => String(info.message))
       ),
     }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "path-to-regexp": "^6.2.1",
         "reflect-metadata": "0.2.2",
         "toposort": "^2.0.2",
-        "winston": "~3.16.0",
+        "winston": "^3.17.0",
         "yargs": "^15.4.1"
       },
       "bin": {
@@ -6573,9 +6573,9 @@
       "license": "MIT"
     },
     "node_modules/logform": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
-      "integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -9254,22 +9254,22 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.16.0.tgz",
-      "integrity": "sha512-xz7+cyGN5M+4CmmD4Npq1/4T+UZaz7HaeTlAruFUTjk79CNMq+P6H30vlE4z0qfqJ01VHYQwd7OZo03nYm/+lg==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"

--- a/package.json
+++ b/package.json
@@ -31,12 +31,11 @@
     "path-to-regexp": "^6.2.1",
     "reflect-metadata": "0.2.2",
     "toposort": "^2.0.2",
-    "winston": "~3.16.0",
+    "winston": "^3.17.0",
     "yargs": "^15.4.1"
   },
   "overrides": {
-    "glob": "^9.3.5",
-    "logform": "~2.6.1"
+    "glob": "^9.3.5"
   },
   "devDependencies": {
     "@types/commonmark": "^0.27.3",


### PR DESCRIPTION
- adds workaround to (bugged?) breaking change in typings
