### PR TITLE
Enforce `readOnly` as sibling of `$ref`

### DIFF
--- a/lib/swagger/jsonLoader.ts
+++ b/lib/swagger/jsonLoader.ts
@@ -79,8 +79,8 @@ export class JsonLoader implements Loader<Json> {
         ["$"],
         fileContent,
         cache.filePath,
-        false,
-        true
+        /* skipResolveChildRef */ false,
+        /* keepRefSiblings */ true
       );
     }
     this.loadedFiles.push(fileContent);
@@ -103,8 +103,8 @@ export class JsonLoader implements Loader<Json> {
         ["$"],
         fileContent,
         cache.filePath,
-        false,
-        true
+        /* skipResolveChildRef */ false,
+        /* keepRefSiblings */ true
       );
     }
     this.loadedFiles.push(fileContent);

--- a/lib/swagger/jsonLoader.ts
+++ b/lib/swagger/jsonLoader.ts
@@ -74,7 +74,14 @@ export class JsonLoader implements Loader<Json> {
     cache.resolved = fileContent;
     (fileContent as any)[$id] = cache.mockName;
     if (cache.skipResolveRef !== true) {
-      fileContent = await this.resolveRef(fileContent, ["$"], fileContent, cache.filePath, false);
+      fileContent = await this.resolveRef(
+        fileContent,
+        ["$"],
+        fileContent,
+        cache.filePath,
+        false,
+        true
+      );
     }
     this.loadedFiles.push(fileContent);
     return fileContent;
@@ -289,7 +296,8 @@ export class JsonLoader implements Loader<Json> {
             pathArr.concat([idx.toString()]),
             rootObject,
             relativeFilePath,
-            skipResolveChildRef
+            skipResolveChildRef,
+            keepRefSiblings
           );
           if (newRef !== item) {
             // eslint-disable-next-line require-atomic-updates
@@ -314,7 +322,8 @@ export class JsonLoader implements Loader<Json> {
             pathArr.concat([key]),
             rootObject,
             relativeFilePath,
-            skipResolveChildRef || this.skipResolveRefKeys.has(key)
+            skipResolveChildRef || this.skipResolveRefKeys.has(key),
+            keepRefSiblings
           );
           if (newRef !== item) {
             obj[key] = newRef;

--- a/lib/swaggerValidator/ajvSchemaValidator.ts
+++ b/lib/swaggerValidator/ajvSchemaValidator.ts
@@ -45,7 +45,7 @@ export class AjvSchemaValidator implements SchemaValidator {
       // tslint:disable-next-line: no-submodule-imports
       meta: require("ajv/lib/refs/json-schema-draft-04.json"),
       schemaId: "auto",
-      extendRefs: "fail",
+      extendRefs: true,
       format: "full",
       missingRefs: true,
       addUsedSchema: false,

--- a/test/readOnlyValidationTests.ts
+++ b/test/readOnlyValidationTests.ts
@@ -1,5 +1,3 @@
-import * as assert from "assert";
-
 import * as validate from "../lib/validate";
 
 const specPath = `test/modelValidation/swaggers/specification/validateReadOnly/cdn.json`;
@@ -9,40 +7,23 @@ describe("Read Only properties", () => {
     const result = await validate.validateExamples(specPath, "Profiles_Create", {
       consoleLogLevel: "off",
     });
-    assert.strictEqual(
-      result.length,
-      1,
-      `swagger "${specPath}" with operation should contain 1 model validation errors.`
-    );
-    assert.strictEqual(
-      result[0].code === "READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST",
-      true,
-      `swagger "${specPath}" should throw an error with code READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST`
-    );
-    assert.strictEqual(
-      result[0].message,
-      'ReadOnly property "provisioningState" cannot be sent in the request'
-    );
+
+    expect(result).toMatchObject([
+      {
+        code: "READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST",
+        message: 'ReadOnly property "provisioningState" cannot be sent in the request',
+      },
+    ]);
   });
 
   it("for a number value discriminator should throw 2 errors - readonly properties not allowed in request and invalid type", async () => {
     const result = await validate.validateExamples(specPath, "Profiles_Update", {
       consoleLogLevel: "off",
     });
-    assert.strictEqual(
-      result.length,
-      2,
-      `swagger "${specPath}" with operation should contain 2 model validation errors.`
-    );
-    assert.strictEqual(
-      result[0].code === "INVALID_TYPE",
-      true,
-      `swagger "${specPath}" should throw an error with code READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST`
-    );
-    assert.strictEqual(
-      result[1].code === "READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST",
-      true,
-      `swagger "${specPath}" should throw an error with code READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST`
-    );
+
+    expect(result).toMatchObject([
+      { code: "INVALID_TYPE" },
+      { code: "READONLY_PROPERTY_NOT_ALLOWED_IN_REQUEST" },
+    ]);
   });
 });


### PR DESCRIPTION
- Fixes #1063

The changes in this PR should ensure all codepaths support `$ref` siblings, and they may even be overkill.  Before merging, the code changes should be tested invidually to determine their impact and necessity.

However, my biggest concern is compat.  Many tests in this PR are failing, because the tests assume oav **doesn't** throw for for `readOnly` as a sibling of `$ref`.

For example, this spec in main, might rely on `oav` (or other tools) existing behavior of `$ref` siblings:

```
"instanceView": {
  "$ref": "#/definitions/CapacityReservationGroupInstanceView",
  "readOnly": true,
  "description": "The capacity reservation group instance view which has the list of instance views for all the capacity reservations that belong to the capacity reservation group."
}
```

https://github.com/Azure/azure-rest-api-specs/blob/131b265e5626c867683ddb4770610348fc98d740/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2022-08-01/capacityReservation.json#L755-L759

My conclusion, the compat risk of this change would outweigh the benefits, so I don't think it should be merged.