### PR TITLE
[dependabot.yml] Enable for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
 updates:
+  # repo does not use GitHub Actions yet, but let's enable dependabot so we don't forget
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     cooldown:
       default-days: 7
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    cooldown:
-      default-days: 7
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
- Repo does not use actions yet, but let's enable now so we don't forget
- Reduce frequency of npm updates from daily to weekly