### PR TITLE
Enforce CFSClean for Network Isolation

### DIFF
--- a/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+++ b/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
@@ -1,0 +1,41 @@
+parameters:
+  - name: npmrcPath
+    type: string
+    # When empty, defaults to the agent user's .npmrc ($HOME/.npmrc on
+    # Linux/macOS, %USERPROFILE%\.npmrc on Windows) so every subsequent
+    # npm / pnpm / npx call in the job inherits the registry + auth.
+    default: ""
+  - name: registryUrl
+    type: string
+    default: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
+  - name: CustomCondition
+    type: string
+    default: succeeded()
+  - name: ServiceConnection
+    type: string
+    default: ""
+
+steps:
+  - pwsh: |
+      $npmrcPath = '${{ parameters.npmrcPath }}'
+      if (-not $npmrcPath) { $npmrcPath = Join-Path $HOME '.npmrc' }
+
+      Write-Host "Creating .npmrc file $npmrcPath for registry ${{ parameters.registryUrl }}"
+      $parentFolder = Split-Path -Path $npmrcPath -Parent
+
+      if ($parentFolder -and -not (Test-Path $parentFolder)) {
+        Write-Host "Creating folder $parentFolder"
+        New-Item -Path $parentFolder -ItemType Directory | Out-Null
+      }
+
+      "registry=${{ parameters.registryUrl }}" | Out-File $npmrcPath
+      Write-Host "##vso[task.setvariable variable=resolvedNpmrcPath]$npmrcPath"
+    displayName: "Create .npmrc"
+    condition: ${{ parameters.CustomCondition }}
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate .npmrc
+    condition: ${{ parameters.CustomCondition }}
+    inputs:
+      workingFile: $(resolvedNpmrcPath)
+      azureDevOpsServiceConnection: ${{ parameters.ServiceConnection }}

--- a/eng/templates/stages/1es-redirect.yml
+++ b/eng/templates/stages/1es-redirect.yml
@@ -36,6 +36,7 @@ extends:
         - 1ES.PT.Tag-refs/tags/canary
     settings:
       skipBuildTagsForGitHubPullRequests: true
+      networkIsolationPolicy: Permissive, CFSClean
     sdl:
       git:
         longpaths: true

--- a/eng/templates/stages/examples-regression.yml
+++ b/eng/templates/stages/examples-regression.yml
@@ -1,39 +1,39 @@
 # this pipeline produces no artifacts, and therefore should be classified as non-production if run as a standalone build.
 stages:
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      - stage: Run_Sample_Regression
-        dependsOn: []
-        displayName: Run Sample Regression
-        variables:
-          - template: /eng/templates/variables/image.yml
-        jobs:
-          - job: SampleRegression
-            pool:
-              name: $(LINUXPOOL)
-              image: $(LINUXVMIMAGE)
-              os: linux
-            steps:
-              - checkout: self
-                submodules: true
-              - template: /eng/templates/steps/simple-regression-steps.yml
-                parameters:
-                  NpmEnvironment: "slow-test-sample"
+    - stage: Run_Sample_Regression
+      dependsOn: []
+      displayName: Run Sample Regression
+      variables:
+        - template: /eng/templates/variables/image.yml
+      jobs:
+        - job: SampleRegression
+          pool:
+            name: $(LINUXPOOL)
+            image: $(LINUXVMIMAGE) 
+            os: linux
+          steps:
+            - checkout: self
+              submodules: true
+            - template: /eng/templates/steps/simple-regression-steps.yml
+              parameters:
+                NpmEnvironment: 'slow-test-sample'
 
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-      - stage: Run_Example_Regression
-        displayName: Run Full Regression
-        variables:
-          - template: /eng/templates/variables/image.yml
-        dependsOn: []
-        jobs:
-          - job: ExampleRegression
-            pool:
-              name: $(LINUXPOOL)
-              image: $(LINUXVMIMAGE)
-              os: linux
-            steps:
-              - checkout: self
-                submodules: true
-              - template: /eng/templates/steps/simple-regression-steps.yml
-                parameters:
-                  NpmEnvironment: "slow-test"
+    - stage: Run_Example_Regression
+      displayName: Run Full Regression
+      variables:
+        - template: /eng/templates/variables/image.yml
+      dependsOn: []
+      jobs:
+        - job: ExampleRegression
+          pool:
+            name: $(LINUXPOOL)
+            image: $(LINUXVMIMAGE) 
+            os: linux
+          steps:
+            - checkout: self
+              submodules: true
+            - template: /eng/templates/steps/simple-regression-steps.yml
+              parameters:
+                NpmEnvironment: 'slow-test'

--- a/eng/templates/stages/examples-regression.yml
+++ b/eng/templates/stages/examples-regression.yml
@@ -1,39 +1,39 @@
 # this pipeline produces no artifacts, and therefore should be classified as non-production if run as a standalone build.
 stages:
   - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-    - stage: Run_Sample_Regression
-      dependsOn: []
-      displayName: Run Sample Regression
-      variables:
-        - template: /eng/templates/variables/image.yml
-      jobs:
-        - job: SampleRegression
-          pool:
-            name: $(LINUXPOOL)
-            image: $(LINUXVMIMAGE) 
-            os: linux
-          steps:
-            - checkout: self
-              submodules: true
-            - template: /eng/templates/steps/simple-regression-steps.yml
-              parameters:
-                NpmEnvironment: 'slow-test-sample'
+      - stage: Run_Sample_Regression
+        dependsOn: []
+        displayName: Run Sample Regression
+        variables:
+          - template: /eng/templates/variables/image.yml
+        jobs:
+          - job: SampleRegression
+            pool:
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
+              os: linux
+            steps:
+              - checkout: self
+                submodules: true
+              - template: /eng/templates/steps/simple-regression-steps.yml
+                parameters:
+                  NpmEnvironment: "slow-test-sample"
 
   - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-    - stage: Run_Example_Regression
-      displayName: Run Full Regression
-      variables:
-        - template: /eng/templates/variables/image.yml
-      dependsOn: []
-      jobs:
-        - job: ExampleRegression
-          pool:
-            name: $(LINUXPOOL)
-            image: $(LINUXVMIMAGE) 
-            os: linux
-          steps:
-            - checkout: self
-              submodules: true
-            - template: /eng/templates/steps/simple-regression-steps.yml
-              parameters:
-                NpmEnvironment: 'slow-test'
+      - stage: Run_Example_Regression
+        displayName: Run Full Regression
+        variables:
+          - template: /eng/templates/variables/image.yml
+        dependsOn: []
+        jobs:
+          - job: ExampleRegression
+            pool:
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
+              os: linux
+            steps:
+              - checkout: self
+                submodules: true
+              - template: /eng/templates/steps/simple-regression-steps.yml
+                parameters:
+                  NpmEnvironment: "slow-test"

--- a/eng/templates/stages/oav.yml
+++ b/eng/templates/stages/oav.yml
@@ -29,16 +29,6 @@ extends:
 
               - bash: npm ci
                 displayName: "npm ci"
-                retryCountOnTaskFailure: 3
-                env:
-                  NPM_CONFIG_USERCONFIG: $(resolvedNpmrcPath)
-                  NPM_CONFIG_REPLACE_REGISTRY_HOST: always
-                  NPM_CONFIG_ALWAYS_AUTH: true
-                  NPM_CONFIG_CACHE: $(Pipeline.Workspace)/.npm
-                  NPM_CONFIG_FETCH_RETRIES: 5
-                  NPM_CONFIG_FETCH_RETRY_FACTOR: 2
-                  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: 10000
-                  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: 120000
 
               - task: Npm@1
                 displayName: "npm run build"
@@ -68,10 +58,6 @@ extends:
               - task: Npm@1
                 displayName: "npm pack"
                 condition: succeededOrFailed()
-                env:
-                  NPM_CONFIG_USERCONFIG: $(resolvedNpmrcPath)
-                  NPM_CONFIG_REPLACE_REGISTRY_HOST: always
-                  NPM_CONFIG_ALWAYS_AUTH: true
                 inputs:
                   command: custom
                   verbose: false
@@ -86,62 +72,62 @@ extends:
 
               - template: /eng/templates/steps/publish-1es-artifact.yml
                 parameters:
-                  ArtifactName: "oav"
-                  ArtifactPath: "$(Build.ArtifactStagingDirectory)"
+                  ArtifactName: 'oav'
+                  ArtifactPath: '$(Build.ArtifactStagingDirectory)'
                   CustomCondition: succeededOrFailed()
 
       - template: /eng/templates/stages/examples-regression.yml
 
       # only include if running on `internal` build with manual queue, otherwise never include
       - ${{ if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
-          - stage: Publish
-            displayName: Publish
-            dependsOn: Build_And_Test
+        - stage: Publish
+          displayName: Publish
+          dependsOn: Build_And_Test
 
-            jobs:
-              - deployment: Publish
-                environment: "package-publish"
-                pool:
-                  name: azsdk-pool
-                  image: ubuntu-24.04
-                  os: linux
+          jobs:
+            - deployment: Publish
+              environment: 'package-publish'
+              pool:
+                name: azsdk-pool
+                image: ubuntu-24.04
+                os: linux
 
-                variables:
-                  - name: ArtifactPath
-                    value: $(Pipeline.Workspace)/oav
+              variables:
+              - name: ArtifactPath
+                value: $(Pipeline.Workspace)/oav
 
-                templateContext:
-                  type: releaseJob
-                  isProduction: true
-                  inputs:
-                    - input: pipelineArtifact
-                      artifactName: oav
-                      itemPattern: "**/*.tgz"
-                      targetPath: $(ArtifactPath)
+              templateContext:
+                type: releaseJob
+                isProduction: true
+                inputs:
+                - input: pipelineArtifact
+                  artifactName: oav
+                  itemPattern: '**/*.tgz'
+                  targetPath: $(ArtifactPath)
 
-                strategy:
-                  runOnce:
-                    deploy:
-                      steps:
-                        - pwsh: |
-                            Write-Host "Will deploy with tag of latest"
-                            Get-ChildItem "$(ArtifactPath)" *.tgz -Recurse | % { Write-Host $_.FullName }
-                          displayName: Packages to be published
+              strategy:
+                runOnce:
+                  deploy:
+                    steps:
+                    - pwsh: |
+                        Write-Host "Will deploy with tag of latest"
+                        Get-ChildItem "$(ArtifactPath)" *.tgz -Recurse | % { Write-Host $_.FullName }
+                      displayName: Packages to be published
 
-                        - task: EsrpRelease@9
-                          displayName: "Publish oav to ESRP"
-                          inputs:
-                            ConnectedServiceName: "Azure SDK PME Managed Identity"
-                            ClientId: "5f81938c-2544-4f1f-9251-dd9de5b8a81b"
-                            DomainTenantId: "975f013f-7f24-47e8-a7d3-abc4752bf346"
-                            UseManagedIdentity: true
-                            KeyVaultName: "kv-azuresdk-codesign"
-                            SignCertName: "azure-sdk-esrp-release-certificate"
-                            Intent: "PackageDistribution"
-                            ContentType: "npm"
-                            FolderLocation: $(ArtifactPath)
-                            Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
-                            Approvers: "azuresdk@microsoft.com"
-                            ServiceEndpointUrl: "https://api.esrp.microsoft.com"
-                            MainPublisher: "ESRPRELPACMANTEST"
-                            productstate: latest
+                    - task: EsrpRelease@9
+                      displayName: 'Publish oav to ESRP'
+                      inputs:
+                        ConnectedServiceName: 'Azure SDK PME Managed Identity'
+                        ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+                        DomainTenantId: '975f013f-7f24-47e8-a7d3-abc4752bf346'
+                        UseManagedIdentity: true
+                        KeyVaultName: 'kv-azuresdk-codesign'
+                        SignCertName: 'azure-sdk-esrp-release-certificate'
+                        Intent: 'PackageDistribution'
+                        ContentType: 'npm'
+                        FolderLocation: $(ArtifactPath)
+                        Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+                        Approvers: 'azuresdk@microsoft.com'
+                        ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                        MainPublisher: 'ESRPRELPACMANTEST'
+                        productstate: latest

--- a/eng/templates/stages/oav.yml
+++ b/eng/templates/stages/oav.yml
@@ -13,23 +13,32 @@ extends:
 
             pool:
               name: $(LINUXPOOL)
-              image: $(LINUXVMIMAGE) 
+              image: $(LINUXVMIMAGE)
               os: linux
 
             steps:
               - checkout: self
                 submodules: true
 
+              - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
               - task: UseNode@1
                 inputs:
                   version: "22.x"
                 displayName: "Use Node 22"
 
-              - task: Npm@1
+              - bash: npm ci
                 displayName: "npm ci"
-                inputs:
-                  command: ci
-                  verbose: false
+                retryCountOnTaskFailure: 3
+                env:
+                  NPM_CONFIG_USERCONFIG: $(resolvedNpmrcPath)
+                  NPM_CONFIG_REPLACE_REGISTRY_HOST: always
+                  NPM_CONFIG_ALWAYS_AUTH: true
+                  NPM_CONFIG_CACHE: $(Pipeline.Workspace)/.npm
+                  NPM_CONFIG_FETCH_RETRIES: 5
+                  NPM_CONFIG_FETCH_RETRY_FACTOR: 2
+                  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: 10000
+                  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: 120000
 
               - task: Npm@1
                 displayName: "npm run build"
@@ -59,6 +68,10 @@ extends:
               - task: Npm@1
                 displayName: "npm pack"
                 condition: succeededOrFailed()
+                env:
+                  NPM_CONFIG_USERCONFIG: $(resolvedNpmrcPath)
+                  NPM_CONFIG_REPLACE_REGISTRY_HOST: always
+                  NPM_CONFIG_ALWAYS_AUTH: true
                 inputs:
                   command: custom
                   verbose: false
@@ -73,62 +86,62 @@ extends:
 
               - template: /eng/templates/steps/publish-1es-artifact.yml
                 parameters:
-                  ArtifactName: 'oav'
-                  ArtifactPath: '$(Build.ArtifactStagingDirectory)'
+                  ArtifactName: "oav"
+                  ArtifactPath: "$(Build.ArtifactStagingDirectory)"
                   CustomCondition: succeededOrFailed()
 
       - template: /eng/templates/stages/examples-regression.yml
 
       # only include if running on `internal` build with manual queue, otherwise never include
       - ${{ if and(in(variables['Build.Reason'], 'Manual', ''), eq(variables['System.TeamProject'], 'internal'))}}:
-        - stage: Publish
-          displayName: Publish
-          dependsOn: Build_And_Test
+          - stage: Publish
+            displayName: Publish
+            dependsOn: Build_And_Test
 
-          jobs:
-            - deployment: Publish
-              environment: 'package-publish'
-              pool:
-                name: azsdk-pool
-                image: ubuntu-24.04
-                os: linux
+            jobs:
+              - deployment: Publish
+                environment: "package-publish"
+                pool:
+                  name: azsdk-pool
+                  image: ubuntu-24.04
+                  os: linux
 
-              variables:
-              - name: ArtifactPath
-                value: $(Pipeline.Workspace)/oav
+                variables:
+                  - name: ArtifactPath
+                    value: $(Pipeline.Workspace)/oav
 
-              templateContext:
-                type: releaseJob
-                isProduction: true
-                inputs:
-                - input: pipelineArtifact
-                  artifactName: oav
-                  itemPattern: '**/*.tgz'
-                  targetPath: $(ArtifactPath)
+                templateContext:
+                  type: releaseJob
+                  isProduction: true
+                  inputs:
+                    - input: pipelineArtifact
+                      artifactName: oav
+                      itemPattern: "**/*.tgz"
+                      targetPath: $(ArtifactPath)
 
-              strategy:
-                runOnce:
-                  deploy:
-                    steps:
-                    - pwsh: |
-                        Write-Host "Will deploy with tag of latest"
-                        Get-ChildItem "$(ArtifactPath)" *.tgz -Recurse | % { Write-Host $_.FullName }
-                      displayName: Packages to be published
+                strategy:
+                  runOnce:
+                    deploy:
+                      steps:
+                        - pwsh: |
+                            Write-Host "Will deploy with tag of latest"
+                            Get-ChildItem "$(ArtifactPath)" *.tgz -Recurse | % { Write-Host $_.FullName }
+                          displayName: Packages to be published
 
-                    - task: EsrpRelease@9
-                      displayName: 'Publish oav to ESRP'
-                      inputs:
-                        ConnectedServiceName: 'Azure SDK PME Managed Identity'
-                        ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
-                        DomainTenantId: '975f013f-7f24-47e8-a7d3-abc4752bf346'
-                        UseManagedIdentity: true
-                        KeyVaultName: 'kv-azuresdk-codesign'
-                        SignCertName: 'azure-sdk-esrp-release-certificate'
-                        Intent: 'PackageDistribution'
-                        ContentType: 'npm'
-                        FolderLocation: $(ArtifactPath)
-                        Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
-                        Approvers: 'azuresdk@microsoft.com'
-                        ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-                        MainPublisher: 'ESRPRELPACMANTEST'
-                        productstate: latest
+                        - task: EsrpRelease@9
+                          displayName: "Publish oav to ESRP"
+                          inputs:
+                            ConnectedServiceName: "Azure SDK PME Managed Identity"
+                            ClientId: "5f81938c-2544-4f1f-9251-dd9de5b8a81b"
+                            DomainTenantId: "975f013f-7f24-47e8-a7d3-abc4752bf346"
+                            UseManagedIdentity: true
+                            KeyVaultName: "kv-azuresdk-codesign"
+                            SignCertName: "azure-sdk-esrp-release-certificate"
+                            Intent: "PackageDistribution"
+                            ContentType: "npm"
+                            FolderLocation: $(ArtifactPath)
+                            Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+                            Approvers: "azuresdk@microsoft.com"
+                            ServiceEndpointUrl: "https://api.esrp.microsoft.com"
+                            MainPublisher: "ESRPRELPACMANTEST"
+                            productstate: latest

--- a/eng/templates/steps/simple-regression-steps.yml
+++ b/eng/templates/steps/simple-regression-steps.yml
@@ -4,16 +4,25 @@ parameters:
     default: "slow-test"
 
 steps:
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+
   - task: UseNode@1
     inputs:
       version: "22.x"
     displayName: "Use Node 22"
 
-  - task: Npm@1
+  - bash: npm ci
     displayName: "npm ci"
-    inputs:
-      command: ci
-      verbose: false
+    retryCountOnTaskFailure: 3
+    env:
+      NPM_CONFIG_USERCONFIG: $(resolvedNpmrcPath)
+      NPM_CONFIG_REPLACE_REGISTRY_HOST: always
+      NPM_CONFIG_ALWAYS_AUTH: true
+      NPM_CONFIG_CACHE: $(Pipeline.Workspace)/.npm
+      NPM_CONFIG_FETCH_RETRIES: 5
+      NPM_CONFIG_FETCH_RETRY_FACTOR: 2
+      NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: 10000
+      NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: 120000
 
   - task: Npm@1
     displayName: "npm run ${{ parameters.NpmEnvironment }}"
@@ -44,4 +53,4 @@ steps:
   - template: /eng/templates/steps/publish-1es-artifact.yml
     parameters:
       ArtifactName: "snapshot-patch-${{ parameters.NpmEnvironment }}"
-      ArtifactPath: '$(Build.ArtifactStagingDirectory)'
+      ArtifactPath: "$(Build.ArtifactStagingDirectory)"

--- a/eng/templates/steps/simple-regression-steps.yml
+++ b/eng/templates/steps/simple-regression-steps.yml
@@ -13,16 +13,6 @@ steps:
 
   - bash: npm ci
     displayName: "npm ci"
-    retryCountOnTaskFailure: 3
-    env:
-      NPM_CONFIG_USERCONFIG: $(resolvedNpmrcPath)
-      NPM_CONFIG_REPLACE_REGISTRY_HOST: always
-      NPM_CONFIG_ALWAYS_AUTH: true
-      NPM_CONFIG_CACHE: $(Pipeline.Workspace)/.npm
-      NPM_CONFIG_FETCH_RETRIES: 5
-      NPM_CONFIG_FETCH_RETRY_FACTOR: 2
-      NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: 10000
-      NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: 120000
 
   - task: Npm@1
     displayName: "npm run ${{ parameters.NpmEnvironment }}"
@@ -53,4 +43,4 @@ steps:
   - template: /eng/templates/steps/publish-1es-artifact.yml
     parameters:
       ArtifactName: "snapshot-patch-${{ parameters.NpmEnvironment }}"
-      ArtifactPath: "$(Build.ArtifactStagingDirectory)"
+      ArtifactPath: '$(Build.ArtifactStagingDirectory)'


### PR DESCRIPTION
This pull request makes a small configuration update to the `1es-redirect.yml` pipeline template. The main change is the addition of a `networkIsolationPolicy` setting.

* Pipeline configuration:
  * Added `networkIsolationPolicy: Permissive, CFSClean` to the pipeline settings in `1es-redirect.yml` to modify network isolation behavior.